### PR TITLE
[ADD] Preview code

### DIFF
--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		BA5A433E28F2FF47008DCDCC /* ProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5A433D28F2FF47008DCDCC /* ProductCoordinator.swift */; };
 		BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */; };
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
+		BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABC84B128F58F5A00D6DF45 /* Preview.swift */; };
 		BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */; };
 		E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */; };
 		E505D9ED28CF5B4A00EEFC65 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EC28CF5B4A00EEFC65 /* SceneDelegate.swift */; };
@@ -65,6 +66,7 @@
 		BA5A433D28F2FF47008DCDCC /* ProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCoordinator.swift; sourceTree = "<group>"; };
 		BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		BAA0580F28D36F75000CDD11 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		BABC84B128F58F5A00D6DF45 /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCollectionHeaderView.swift; sourceTree = "<group>"; };
 		E505D9E728CF5B4A00EEFC65 /* PPAK_CVS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PPAK_CVS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 				A5F8288928DEC0CF00C5D6A2 /* UIButton+.swift */,
 				A5F8288D28DED76700C5D6A2 /* UILabel+.swift */,
 				BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */,
+				BABC84B128F58F5A00D6DF45 /* Preview.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 				BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */,
 				A5F8288C28DECEE700C5D6A2 /* Strings.swift in Sources */,
 				BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */,
+				BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */,
 				E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */,
 				E505D9ED28CF5B4A00EEFC65 /* SceneDelegate.swift in Sources */,
 				E580BF2528E0649E00BE7ADC /* HomeCollectionHeaderView.swift in Sources */,

--- a/PPAK_CVS/Configuration/Extensions/Preview.swift
+++ b/PPAK_CVS/Configuration/Extensions/Preview.swift
@@ -1,0 +1,46 @@
+//
+//  Preview.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2022/10/11.
+//
+
+import UIKit
+import SwiftUI
+
+#if DEBUG
+extension UIViewController {
+  private struct Preview: UIViewControllerRepresentable {
+    let viewController: UIViewController
+
+    func makeUIViewController(context: Context) -> UIViewController {
+      return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+  }
+
+  func toPreview() -> some View {
+    Preview(viewController: self)
+  }
+}
+
+extension UIView {
+  private struct Preview: UIViewRepresentable {
+    typealias UIViewType = UIView
+    let view: UIView
+
+    func makeUIView(context: Context) -> UIView {
+      return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+    }
+  }
+
+  func toPreview() -> some View {
+    Preview(view: self)
+  }
+}
+#endif


### PR DESCRIPTION
## Features ✨

- UIKit에서 사용할 수 있는 Preview Code 생성(ViewController / View)

## To Reviewers


ViewController와 View를 빌드과정 없이 미리보기 할 수 있습니다.
TableView / Collection Cell도 따로 xib처럼 확인 가능합니다.
여러 Device를 한번에 확인 가능합니다.<sup>[[1]](#ref1)</sup>
Preview 코드는 Snippets로 관리하여 사용하시면 편할 것 같아요.
```swift
#if canImport(SwiftUI) && DEBUG
import SwiftUI
struct ViewControllerPreView:PreviewProvider {
  static var previews: some View {
    // ViewController().toPreview()
  }
}
#endif
```

```swift
#if canImport(SwiftUI) && DEBUG
import SwiftUI
struct ViewPreview: PreviewProvider {
  static var previews: some View {
    // SomeView().toPreview()
  }
}
#endif
```

### Reference

1. <a id="ref1">[previewDevice method](https://developer.apple.com/documentation/swiftui/view/previewdevice(_:))</a>
