### PR TITLE
UIColor Initializer 개정

### DIFF
--- a/PPAK_CVS/Configuration/Extensions/UIColor+.swift
+++ b/PPAK_CVS/Configuration/Extensions/UIColor+.swift
@@ -8,7 +8,11 @@
 import UIKit
 
 extension UIColor {
-
+  
+  /// 16진수의 정수형으로 UIColor를 생성합니다.
+  /// - Parameters:
+  ///   - hex: 16진수
+  ///   - alpha: 불투명도, 0부터 1사이의 값
   convenience init(hex: Int, alpha: CGFloat = 1.0) {
     let components = (
       red: CGFloat((hex >> 16) & 0xff) / 255,

--- a/PPAK_CVS/Configuration/Extensions/UIColor+.swift
+++ b/PPAK_CVS/Configuration/Extensions/UIColor+.swift
@@ -17,6 +17,24 @@ extension UIColor {
     )
     self.init(red: components.red, green: components.green, blue: components.blue, alpha: alpha)
   }
+  
+  /// 16진수 형태의 문자열로 UIColor를 생성합니다.
+  /// - Parameters:
+  ///   - hex: 16진수 형태의 문자열
+  ///   - alpha: 불투명도, 0부터 1 사이의 값
+  convenience init?(hex: String, alpha: CGFloat = 1.0) {
+    var hexString = hex
+    if hexString.hasPrefix("#") {
+      hexString.removeFirst()
+    }
+    if hexString.hasPrefix("0x") {
+      hexString.removeFirst(2)
+    }
+    
+    guard let hexColor = Int(hexString, radix: 16) else { return nil }
+    
+    self.init(hex: hexColor, alpha: alpha)
+  }
 }
 
 // MARK: - Store's SymbolColor

--- a/PPAK_CVS/Configuration/Extensions/UIColor+.swift
+++ b/PPAK_CVS/Configuration/Extensions/UIColor+.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 extension UIColor {
-  
+
   /// 16진수의 정수형으로 UIColor를 생성합니다.
   /// - Parameters:
   ///   - hex: 16진수
   ///   - alpha: 불투명도, 0부터 1사이의 값
-  convenience init(hex: Int, alpha: CGFloat = 1.0) {
+  convenience init(hex: UInt, alpha: CGFloat = 1.0) {
     let components = (
       red: CGFloat((hex >> 16) & 0xff) / 255,
       green: CGFloat((hex >> 08) & 0xff) / 255,
@@ -21,7 +21,7 @@ extension UIColor {
     )
     self.init(red: components.red, green: components.green, blue: components.blue, alpha: alpha)
   }
-  
+
   /// 16진수 형태의 문자열로 UIColor를 생성합니다.
   /// - Parameters:
   ///   - hex: 16진수 형태의 문자열
@@ -34,9 +34,9 @@ extension UIColor {
     if hexString.hasPrefix("0x") {
       hexString.removeFirst(2)
     }
-    
-    guard let hexColor = Int(hexString, radix: 16) else { return nil }
-    
+
+    guard let hexColor = UInt(hexString, radix: 16) else { return nil }
+
     self.init(hex: hexColor, alpha: alpha)
   }
 }


### PR DESCRIPTION
## Features ✨

- String to UIColor initializer 추가
- `Int` initializer를 `UInt`로 수정
- 주석 추가

String UIColor initializer는 `Failable Initializer`로 처리해두었습니다(16진수로 값이 들어오지 못할 경우 처리).

## Example

```swift
let white: UIColor =  .init(hex: 0xFFFFFF) // ✅
let white: UIColor? =  .init(hex: "0xFFFFFF") // ✅
let white: UIColor? =  .init(hex: "#FFFFFF") // ✅
let white: UIColor? =  .init(hex: "FFFFFF") // ✅
let white: UIColor? =  .init(hex: "#ffFfFf") // ✅
```

## Issue

- Resolved: #33 (응답 3)