### PR TITLE
Firebase DB 클래스 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,swift,xcode
+
+# GoogleService-info
+
+GoogleService-info.plist

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		BA9EDA912917F98B00B97C23 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BA9EDA902917F98B00B97C23 /* FirebaseFirestoreSwift */; };
 		BA9EDA9B2918BF2B00B97C23 /* ProductModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */; };
 		BA9EDA9D2918BF9000B97C23 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EDA9C2918BF8F00B97C23 /* Date+.swift */; };
+		BA9EDA9F2918C3C800B97C23 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BA9EDA9E2918C3C800B97C23 /* GoogleService-Info.plist */; };
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
@@ -96,6 +97,7 @@
 		BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductModel.swift; sourceTree = "<group>"; };
 		BA9EDA9C2918BF8F00B97C23 /* Date+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
+		BA9EDA9E2918C3C800B97C23 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BAA0580F28D36F75000CDD11 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		BAA0F53428FD353500B632AC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 			children = (
 				BA27023228CF5EF30039D9EA /* Configuration */,
 				BA27023328CF5EFF0039D9EA /* Sources */,
+				BA9EDA9E2918C3C800B97C23 /* GoogleService-Info.plist */,
 				E505D9F828CF5B4B00EEFC65 /* Info.plist */,
 			);
 			path = PPAK_CVS;
@@ -445,6 +448,7 @@
 				A5932EA328E044CB00457AD3 /* onboarding1.json in Resources */,
 				A5932EA528E045EF00457AD3 /* onboarding3.json in Resources */,
 				A5932EA728E0472B00457AD3 /* onboarding2.json in Resources */,
+				BA9EDA9F2918C3C800B97C23 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */; };
 		BA9EDA912917F98B00B97C23 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BA9EDA902917F98B00B97C23 /* FirebaseFirestoreSwift */; };
 		BA9EDA9B2918BF2B00B97C23 /* ProductModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */; };
+		BA9EDA9D2918BF9000B97C23 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EDA9C2918BF8F00B97C23 /* Date+.swift */; };
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
@@ -94,6 +95,7 @@
 		BA8CF87B290D10CB009770C0 /* ProductHeaderViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHeaderViewViewModel.swift; sourceTree = "<group>"; };
 		BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductModel.swift; sourceTree = "<group>"; };
+		BA9EDA9C2918BF8F00B97C23 /* Date+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		BAA0580F28D36F75000CDD11 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		BAA0F53428FD353500B632AC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 		A5F8288828DEC09B00C5D6A2 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				BA9EDA9C2918BF8F00B97C23 /* Date+.swift */,
 				A5F8288928DEC0CF00C5D6A2 /* UIButton+.swift */,
 				A5F8288D28DED76700C5D6A2 /* UILabel+.swift */,
 				BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */,
@@ -501,6 +504,7 @@
 				BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */,
 				BAA21ACE29155E4A00056DB6 /* CVSDatabase.swift in Sources */,
 				E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */,
+				BA9EDA9D2918BF9000B97C23 /* Date+.swift in Sources */,
 				E505D9ED28CF5B4A00EEFC65 /* SceneDelegate.swift in Sources */,
 				E580BF2528E0649E00BE7ADC /* HomeCollectionHeaderView.swift in Sources */,
 				E580BF2328E0646200BE7ADC /* GoodsCell.swift in Sources */,

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		BA8CF87C290D10CB009770C0 /* ProductHeaderViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8CF87B290D10CB009770C0 /* ProductHeaderViewViewModel.swift */; };
 		BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */; };
 		BA9EDA912917F98B00B97C23 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BA9EDA902917F98B00B97C23 /* FirebaseFirestoreSwift */; };
+		BA9EDA9B2918BF2B00B97C23 /* ProductModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */; };
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
@@ -92,6 +93,7 @@
 		BA5A433D28F2FF47008DCDCC /* ProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCoordinator.swift; sourceTree = "<group>"; };
 		BA8CF87B290D10CB009770C0 /* ProductHeaderViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHeaderViewViewModel.swift; sourceTree = "<group>"; };
 		BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
+		BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductModel.swift; sourceTree = "<group>"; };
 		BAA0580F28D36F75000CDD11 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		BAA0F53428FD353500B632AC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 			children = (
 				A5932EA928E047E000457AD3 /* OnboardingDataModel.swift */,
 				9CCFA4FF2901841400963A95 /* EventInfoResponseModel.swift */,
+				BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -478,6 +481,7 @@
 				A5F8288728DEB63D00C5D6A2 /* FTUXStorage.swift in Sources */,
 				9CCFA5002901841400963A95 /* EventInfoResponseModel.swift in Sources */,
 				A5F8288A28DEC0CF00C5D6A2 /* UIButton+.swift in Sources */,
+				BA9EDA9B2918BF2B00B97C23 /* ProductModel.swift in Sources */,
 				A5F8288E28DED76700C5D6A2 /* UILabel+.swift in Sources */,
 				9C798F8C28EAEC5D00FE250C /* CvsType.swift in Sources */,
 				BA5A433E28F2FF47008DCDCC /* ProductCoordinator.swift in Sources */,

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		BAA21ACB29154DE000056DB6 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = BAA21ACA29154DE000056DB6 /* FirebaseFirestore */; };
 		BAA21ACE29155E4A00056DB6 /* CVSDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA21ACD29155E4A00056DB6 /* CVSDatabase.swift */; };
 		BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABC84B128F58F5A00D6DF45 /* Preview.swift */; };
+		BAD70BD8291A58CB00C39863 /* SortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD70BD7291A58CB00C39863 /* SortType.swift */; };
 		BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */; };
 		E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */; };
 		E505D9ED28CF5B4A00EEFC65 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EC28CF5B4A00EEFC65 /* SceneDelegate.swift */; };
@@ -103,6 +104,7 @@
 		BAA0F53428FD353500B632AC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		BAA21ACD29155E4A00056DB6 /* CVSDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVSDatabase.swift; sourceTree = "<group>"; };
 		BABC84B128F58F5A00D6DF45 /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
+		BAD70BD7291A58CB00C39863 /* SortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortType.swift; sourceTree = "<group>"; };
 		BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCollectionHeaderView.swift; sourceTree = "<group>"; };
 		E505D9E728CF5B4A00EEFC65 /* PPAK_CVS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PPAK_CVS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 			children = (
 				9C798F8B28EAEC5D00FE250C /* CvsType.swift */,
 				9CCFA4FD28F4585E00963A95 /* EventType.swift */,
+				BAD70BD7291A58CB00C39863 /* SortType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -518,6 +521,7 @@
 				E54D9C4428F1A19000D028B2 /* BookmarkCoordinator.swift in Sources */,
 				BA1CCACB28FB01DE0002FD8C /* ViewModel.swift in Sources */,
 				E5467E4C28D45DFE0031B785 /* BottomCurveView.swift in Sources */,
+				BAD70BD8291A58CB00C39863 /* SortType.swift in Sources */,
 				E54D9C4628F1A19B00D028B2 /* BookmarkViewModel.swift in Sources */,
 				E54D9C4828F1A1A300D028B2 /* BookmarkVC.swift in Sources */,
 				E55BEBE128D6A82400804FCB /* SearchBar.swift in Sources */,

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		BAA21ACE29155E4A00056DB6 /* CVSDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA21ACD29155E4A00056DB6 /* CVSDatabase.swift */; };
 		BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABC84B128F58F5A00D6DF45 /* Preview.swift */; };
 		BAD70BD8291A58CB00C39863 /* SortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD70BD7291A58CB00C39863 /* SortType.swift */; };
+		BAD70BDA291A594F00C39863 /* RequestTypeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD70BD9291A594F00C39863 /* RequestTypeModel.swift */; };
 		BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */; };
 		E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */; };
 		E505D9ED28CF5B4A00EEFC65 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EC28CF5B4A00EEFC65 /* SceneDelegate.swift */; };
@@ -105,6 +106,7 @@
 		BAA21ACD29155E4A00056DB6 /* CVSDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVSDatabase.swift; sourceTree = "<group>"; };
 		BABC84B128F58F5A00D6DF45 /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		BAD70BD7291A58CB00C39863 /* SortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortType.swift; sourceTree = "<group>"; };
+		BAD70BD9291A594F00C39863 /* RequestTypeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTypeModel.swift; sourceTree = "<group>"; };
 		BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCollectionHeaderView.swift; sourceTree = "<group>"; };
 		E505D9E728CF5B4A00EEFC65 /* PPAK_CVS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PPAK_CVS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				A5932EA928E047E000457AD3 /* OnboardingDataModel.swift */,
 				9CCFA4FF2901841400963A95 /* EventInfoResponseModel.swift */,
 				BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */,
+				BAD70BD9291A594F00C39863 /* RequestTypeModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -502,6 +505,7 @@
 				E505D9EF28CF5B4A00EEFC65 /* HomeVC.swift in Sources */,
 				E5A877C028D4A34D002A2402 /* PageControl.swift in Sources */,
 				E5B9965728E2872A00E39566 /* CVSDropdownView.swift in Sources */,
+				BAD70BDA291A594F00C39863 /* RequestTypeModel.swift in Sources */,
 				BA27024928CF618E0039D9EA /* HomeCoordinator.swift in Sources */,
 				BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */,
 				E5103251290B4A0300D2F007 /* UIView+.swift in Sources */,

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		BA5A433E28F2FF47008DCDCC /* ProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5A433D28F2FF47008DCDCC /* ProductCoordinator.swift */; };
 		BA8CF87C290D10CB009770C0 /* ProductHeaderViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8CF87B290D10CB009770C0 /* ProductHeaderViewViewModel.swift */; };
 		BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */; };
+		BA9EDA912917F98B00B97C23 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BA9EDA902917F98B00B97C23 /* FirebaseFirestoreSwift */; };
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
@@ -130,6 +131,7 @@
 				A5932EA028E0435200457AD3 /* Lottie in Frameworks */,
 				BAA21ACB29154DE000056DB6 /* FirebaseFirestore in Frameworks */,
 				E5F9CCA228EF10EA0084CD63 /* RxGesture in Frameworks */,
+				BA9EDA912917F98B00B97C23 /* FirebaseFirestoreSwift in Frameworks */,
 				BA27023F28CF60830039D9EA /* Alamofire in Frameworks */,
 				BA27023928CF60570039D9EA /* SnapKit in Frameworks */,
 				BA27024428CF60A30039D9EA /* RxSwift in Frameworks */,
@@ -284,6 +286,13 @@
 			path = Product;
 			sourceTree = "<group>";
 		};
+		BA9EDA8F2917F98B00B97C23 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		BAA21ACC29155A0F00056DB6 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
@@ -297,6 +306,7 @@
 			children = (
 				E505D9E928CF5B4A00EEFC65 /* PPAK_CVS */,
 				E505D9E828CF5B4A00EEFC65 /* Products */,
+				BA9EDA8F2917F98B00B97C23 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -369,6 +379,7 @@
 				E5F9CCA128EF10EA0084CD63 /* RxGesture */,
 				BA1CCAC128FAFE500002FD8C /* WeakMapTable */,
 				BAA21ACA29154DE000056DB6 /* FirebaseFirestore */,
+				BA9EDA902917F98B00B97C23 /* FirebaseFirestoreSwift */,
 			);
 			productName = PPAK_CVS;
 			productReference = E505D9E728CF5B4A00EEFC65 /* PPAK_CVS.app */;
@@ -826,6 +837,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BA27024528CF61020039D9EA /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		BA9EDA902917F98B00B97C23 /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BAA21AC929154DE000056DB6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
 		};
 		BAA21ACA29154DE000056DB6 /* FirebaseFirestore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
+		BAA21ACB29154DE000056DB6 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = BAA21ACA29154DE000056DB6 /* FirebaseFirestore */; };
 		BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABC84B128F58F5A00D6DF45 /* Preview.swift */; };
 		BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */; };
 		E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */; };
@@ -125,6 +126,7 @@
 				BA27024728CF61020039D9EA /* Kingfisher in Frameworks */,
 				BA1CCAC228FAFE500002FD8C /* WeakMapTable in Frameworks */,
 				A5932EA028E0435200457AD3 /* Lottie in Frameworks */,
+				BAA21ACB29154DE000056DB6 /* FirebaseFirestore in Frameworks */,
 				E5F9CCA228EF10EA0084CD63 /* RxGesture in Frameworks */,
 				BA27023F28CF60830039D9EA /* Alamofire in Frameworks */,
 				BA27023928CF60570039D9EA /* SnapKit in Frameworks */,
@@ -355,6 +357,7 @@
 				A5932E9F28E0435200457AD3 /* Lottie */,
 				E5F9CCA128EF10EA0084CD63 /* RxGesture */,
 				BA1CCAC128FAFE500002FD8C /* WeakMapTable */,
+				BAA21ACA29154DE000056DB6 /* FirebaseFirestore */,
 			);
 			productName = PPAK_CVS;
 			productReference = E505D9E728CF5B4A00EEFC65 /* PPAK_CVS.app */;
@@ -393,6 +396,7 @@
 				A5932E9E28E0435200457AD3 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				E5F9CCA028EF10EA0084CD63 /* XCRemoteSwiftPackageReference "RxGesture" */,
 				BA1CCAC028FAFE500002FD8C /* XCRemoteSwiftPackageReference "WeakMapTable" */,
+				BAA21AC929154DE000056DB6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = E505D9E828CF5B4A00EEFC65 /* Products */;
 			projectDirPath = "";
@@ -752,6 +756,14 @@
 				kind = branch;
 			};
 		};
+		BAA21AC929154DE000056DB6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.0;
+			};
+		};
 		E5F9CCA028EF10EA0084CD63 /* XCRemoteSwiftPackageReference "RxGesture" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RxSwiftCommunity/RxGesture.git";
@@ -802,6 +814,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BA27024528CF61020039D9EA /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		BAA21ACA29154DE000056DB6 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BAA21AC929154DE000056DB6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
 		};
 		E5F9CCA128EF10EA0084CD63 /* RxGesture */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -653,7 +653,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "eungcheol.PPAK-CVS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sfam.cvs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -680,7 +680,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "eungcheol.PPAK-CVS";
+				PRODUCT_BUNDLE_IDENTIFIER = com.sfam.cvs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
 		BAA21ACB29154DE000056DB6 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = BAA21ACA29154DE000056DB6 /* FirebaseFirestore */; };
+		BAA21ACE29155E4A00056DB6 /* CVSDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA21ACD29155E4A00056DB6 /* CVSDatabase.swift */; };
 		BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABC84B128F58F5A00D6DF45 /* Preview.swift */; };
 		BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */; };
 		E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */; };
@@ -93,6 +94,7 @@
 		BAA0580F28D36F75000CDD11 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		BAA0F53428FD353500B632AC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		BAA21ACD29155E4A00056DB6 /* CVSDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVSDatabase.swift; sourceTree = "<group>"; };
 		BABC84B128F58F5A00D6DF45 /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		BAEF774828F412FA006B0274 /* ProductCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCollectionHeaderView.swift; sourceTree = "<group>"; };
 		E505D9E728CF5B4A00EEFC65 /* PPAK_CVS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PPAK_CVS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -216,6 +218,7 @@
 				BAA0F53428FD353500B632AC /* AppCoordinator.swift */,
 				E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */,
 				E505D9EC28CF5B4A00EEFC65 /* SceneDelegate.swift */,
+				BAA21ACC29155A0F00056DB6 /* Managers */,
 				A5932EA828E047B400457AD3 /* Models */,
 				E584487C28D55B9000E25265 /* Scenes */,
 			);
@@ -279,6 +282,14 @@
 				BA5A433B28F2FF15008DCDCC /* ProductVC.swift */,
 			);
 			path = Product;
+			sourceTree = "<group>";
+		};
+		BAA21ACC29155A0F00056DB6 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				BAA21ACD29155E4A00056DB6 /* CVSDatabase.swift */,
+			);
+			path = Managers;
 			sourceTree = "<group>";
 		};
 		E505D9DE28CF5B4A00EEFC65 = {
@@ -473,6 +484,7 @@
 				9C798F8A28EAE9DA00FE250C /* TitleLogoView.swift in Sources */,
 				BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */,
 				BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */,
+				BAA21ACE29155E4A00056DB6 /* CVSDatabase.swift in Sources */,
 				E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */,
 				E505D9ED28CF5B4A00EEFC65 /* SceneDelegate.swift in Sources */,
 				E580BF2528E0649E00BE7ADC /* HomeCollectionHeaderView.swift in Sources */,

--- a/PPAK_CVS/Configuration/Constants/Enum/CvsType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/CvsType.swift
@@ -13,26 +13,14 @@ import UIKit
 ///     - image: 로고이미지 이름
 ///     - bgColor: 태그의 배경색상
 ///     - fontColor: 태그의 폰트색상
+enum CVSType: String, Codable, CaseIterable {
 
-enum CVSType: Codable, CaseIterable {
-
-  case cu // cu
-  case gs // gs25
-  case sevenEleven // sevenEleven
-  case miniStop // miniStop
-  case eMart // eMart
+  case cu = "CU"
+  case gs = "GS25"
+  case sevenEleven = "7-ELEVEn"
+  case miniStop = "MINISTOP"
+  case eMart = "emart24"
   case all
-
-  var title: String {
-    switch self {
-    case .cu: return "CU"
-    case .gs: return "GS25"
-    case .sevenEleven: return "7-ELEVEn"
-    case .miniStop: return "MINISTOP"
-    case .eMart: return "emart24"
-    case .all: return "All"
-    }
-  }
 
   var image: UIImage? {
     switch self {

--- a/PPAK_CVS/Configuration/Constants/Enum/CvsType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/CvsType.swift
@@ -14,7 +14,7 @@ import UIKit
 ///     - bgColor: 태그의 배경색상
 ///     - fontColor: 태그의 폰트색상
 
-enum CVSType {
+enum CVSType: Codable, CaseIterable {
 
   case cu // cu
   case gs // gs25

--- a/PPAK_CVS/Configuration/Constants/Enum/CvsType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/CvsType.swift
@@ -13,7 +13,7 @@ import UIKit
 ///     - image: 로고이미지 이름
 ///     - bgColor: 태그의 배경색상
 ///     - fontColor: 태그의 폰트색상
-enum CVSType: String, Codable, CaseIterable {
+enum CVSType: String, Codable {
 
   case cu = "CU"
   case gs = "GS25"

--- a/PPAK_CVS/Configuration/Constants/Enum/EventType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/EventType.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 /// 이벤트의 종류를 가리키는 Enum Type
-enum EventType: String, Codable, CaseIterable {
+enum EventType: String, Codable {
   case onePlusOne = "1+1"
   case twoPlusOne = "2+1"
   case all = "All"

--- a/PPAK_CVS/Configuration/Constants/Enum/EventType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/EventType.swift
@@ -8,29 +8,8 @@
 import UIKit
 
 /// 이벤트의 종류를 가리키는 Enum Type
-enum EventType: Codable, CaseIterable {
-
-  case onePlusOne
-  case twoPlusOne
-  case allSelectEn
-  case allSelectKr
-
-  var eventTitle: String {
-    switch self {
-    case .onePlusOne: return "1 + 1"
-    case .twoPlusOne: return "2 + 1"
-    case .allSelectEn: return "All"
-    case .allSelectKr: return "전체"
-    }
-  }
+enum EventType: String, Codable, CaseIterable {
+  case onePlusOne = "1+1"
+  case twoPlusOne = "2+1"
+  case all = "All"
 }
-
-
-
-
-///// 이벤트의 종류를 가리키는 Enum Type
-//enum EventType: String, Codable, CaseIterable {
-//  case onePlusOne = "1+1"
-//  case twoPlusOne = "2+1"
-//  case all = "All"
-//}

--- a/PPAK_CVS/Configuration/Constants/Enum/EventType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/EventType.swift
@@ -7,9 +7,8 @@
 
 import UIKit
 
-/// Description
 /// 이벤트의 종류를 가리키는 Enum Type
-enum EventType {
+enum EventType: Codable, CaseIterable {
 
   case onePlusOne
   case twoPlusOne
@@ -25,3 +24,13 @@ enum EventType {
     }
   }
 }
+
+
+
+
+///// 이벤트의 종류를 가리키는 Enum Type
+//enum EventType: String, Codable, CaseIterable {
+//  case onePlusOne = "1+1"
+//  case twoPlusOne = "2+1"
+//  case all = "All"
+//}

--- a/PPAK_CVS/Configuration/Constants/Enum/SortType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/SortType.swift
@@ -1,0 +1,14 @@
+//
+//  SortType.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2022/11/08.
+//
+
+import Foundation
+
+enum SortType {
+  case ascending
+  case descending
+  case none
+}

--- a/PPAK_CVS/Configuration/Constants/Enum/SortType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/SortType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum SortType {
+enum SortType: CaseIterable {
   case ascending
   case descending
   case none

--- a/PPAK_CVS/Configuration/Constants/Enum/SortType.swift
+++ b/PPAK_CVS/Configuration/Constants/Enum/SortType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum SortType: CaseIterable {
+enum SortType {
   case ascending
   case descending
   case none

--- a/PPAK_CVS/Configuration/Extensions/Date+.swift
+++ b/PPAK_CVS/Configuration/Extensions/Date+.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 extension Date {
-  
+
   /// 년도
   var year: Int {
     Calendar.current.component(.year, from: self)
   }
-  
+
   /// 월
   var month: Int {
     Calendar.current.component(.year, from: self)

--- a/PPAK_CVS/Configuration/Extensions/Date+.swift
+++ b/PPAK_CVS/Configuration/Extensions/Date+.swift
@@ -1,0 +1,21 @@
+//
+//  Date+.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2022/11/07.
+//
+
+import Foundation
+
+extension Date {
+  
+  /// 년도
+  var year: Int {
+    Calendar.current.component(.year, from: self)
+  }
+  
+  /// 월
+  var month: Int {
+    Calendar.current.component(.year, from: self)
+  }
+}

--- a/PPAK_CVS/Sources/AppDelegate.swift
+++ b/PPAK_CVS/Sources/AppDelegate.swift
@@ -20,7 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Configuration
     FirebaseApp.configure()
-    let db = Firestore.firestore()
 
     return true
   }

--- a/PPAK_CVS/Sources/AppDelegate.swift
+++ b/PPAK_CVS/Sources/AppDelegate.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import FirebaseCore
+import FirebaseFirestore
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -14,6 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    
+    // Configuration
+    FirebaseApp.configure()
+    let db = Firestore.firestore()
+    
     return true
   }
 

--- a/PPAK_CVS/Sources/AppDelegate.swift
+++ b/PPAK_CVS/Sources/AppDelegate.swift
@@ -17,11 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    
+
     // Configuration
     FirebaseApp.configure()
     let db = Firestore.firestore()
-    
+
     return true
   }
 

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -37,8 +37,11 @@ final class CVSDatabase {
     }
   }
 
-  func informationTask(type: CVSType, eventType: EventType, offset: Int = 0, limit: Int = 10) -> Observable<[ProductModel]> {
-
+  func informationTask(
+    request: RequestTypeModel,
+    offset: Int = 0,
+    limit: Int = 10
+  ) -> Observable<[ProductModel]> {
     return Single<[ProductModel]>.create { observer in
       let task = Task {
         do {

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -18,12 +18,12 @@ final class CVSDatabase {
   static let shared: CVSDatabase = CVSDatabase()
 
   private lazy var database: CollectionReference = Firestore.firestore().collection("sale")
-  
+
   /// 데이터베이스에 저장되어있는 편의점 할인날짜
   var syncKey: Observable<String> {
     return self._syncKey().asObservable()
   }
-  
+
   /// 특정 조건에 맞는 제품을 가져옵니다.
   /// - Parameters:
   ///   - request: 요청할 제품의 조건식을 갖는 모델
@@ -158,7 +158,7 @@ extension CVSDatabase {
 // MARK: - Private Methods
 
 extension CVSDatabase {
-  
+
   private func _syncKey() -> Single<String> {
     return Single.create { [weak self] observer in
       self?.database.document(Name.syncKey).getDocument(as: SyncKeyModel.self) { result in
@@ -180,11 +180,11 @@ extension CVSDatabase {
 
     if model.cvs != .all && model.event != .all {
       query = ref
-        .whereField(Name.cvs, isEqualTo: model.cvs.title)
+        .whereField(Name.cvs, isEqualTo: model.cvs.rawValue)
         .whereField(Name.event, isEqualTo: model.event.rawValue)
     } else if model.cvs != .all {
       query = ref
-        .whereField(Name.cvs, isEqualTo: model.cvs.title)
+        .whereField(Name.cvs, isEqualTo: model.cvs.rawValue)
     } else {
       query = ref
         .whereField(Name.event, isEqualTo: model.event.rawValue)

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -39,13 +39,13 @@ final class CVSDatabase {
 
   private func _query(model: RequestTypeModel, key: String) -> Query {
 
-    var cvsList: [CVSType] = CVSType.allCases.dropLast()
-    var eventList: [EventType] = EventType.allCases.dropLast()
+    var cvsList: [String] = CVSType.allCases.dropLast().map { $0.title }
+    var eventList: [String] = EventType.allCases.dropLast().map { $0.rawValue }
     if model.cvs != .all {
-      cvsList = [model.cvs]
+      cvsList = [model.cvs.title]
     }
     if model.event != .all {
-      eventList = [model.event]
+      eventList = [model.event.rawValue]
     }
 
     let ref = self.database.document(key).collection(Name.item)

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -115,6 +115,9 @@ extension CVSDatabase {
 
     /// 서버에 저장되어있는 데이터가 현재 날짜랑 맞지 않는 경우
     case synchronized
+
+    /// 문서를 찾지 못한 경우
+    case retrieving
   }
 
   private enum Name {

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -1,0 +1,23 @@
+//
+//  CVSDatabase.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2022/11/04.
+//
+
+import Foundation
+
+import FirebaseFirestore
+
+final class CVSDatabase {
+
+  /// The shared singleton firebase object.
+  static let shared: CVSDatabase = CVSDatabase()
+
+  private lazy var db = Firestore.firestore().collection("sale")
+
+//  var isSynchronized: Bool {
+//    db.document("sync_key")
+//  }
+
+}

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -7,7 +7,10 @@
 
 import Foundation
 
+import RxSwift
+import RxCocoa
 import FirebaseFirestore
+import FirebaseFirestoreSwift
 
 final class CVSDatabase {
 

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -93,6 +93,10 @@ extension CVSDatabase {
 
   private enum Name {
     static let syncKey = "sync_key"
+    static let price = "price"
+    static let cvs = "store"
+    static let item = "items"
+    static let event = "tag"
   }
 
   private struct SyncKeyModel: Codable {

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -24,3 +24,29 @@ final class CVSDatabase {
 //  }
 
 }
+
+// MARK: - Models and Constants
+
+extension CVSDatabase {
+
+  enum Error: Swift.Error {
+    
+    /// Firebase를 읽어드리는 데 오류가 발생한 경우
+    case firebase
+    
+    /// 데이터가 잘못 들어와 디코딩이 되지 않는 경우
+    /// 이는 서버측의 데이터타입 문제이거나, 해당 클래스의 타입변경 미스일 때 발생합니다.
+    case decoding
+    
+    /// 서버에 저장되어있는 데이터가 현재 날짜랑 맞지 않는 경우
+    case synchronized
+  }
+
+  private enum Name {
+    static let syncKey = "sync_key"
+  }
+
+  private struct SyncKeyModel: Codable {
+    let month: String
+  }
+}

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -17,7 +17,7 @@ final class CVSDatabase {
   /// The shared singleton firebase object.
   static let shared: CVSDatabase = CVSDatabase()
 
-  private lazy var db = Firestore.firestore().collection("sale")
+  private lazy var database: CollectionReference = Firestore.firestore().collection("sale")
 
 //  var isSynchronized: Bool {
 //    db.document("sync_key")

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -19,6 +19,23 @@ final class CVSDatabase {
 
   private lazy var database: CollectionReference = Firestore.firestore().collection("sale")
 
+  var syncKey: Observable<String> {
+    return self._syncKey().asObservable()
+  }
+
+  private func _syncKey() -> Single<String> {
+    return Single.create { [weak self] observer in
+      self?.database.document(Name.syncKey).getDocument(as: SyncKeyModel.self) { result in
+        switch result {
+        case let .success(keyModel):
+          observer(.success(keyModel.month))
+        case .failure:
+          observer(.failure(Error.firebase))
+        }
+      }
+      return Disposables.create()
+    }
+  }
 }
 
 // MARK: - Models and Constants

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -37,6 +37,29 @@ final class CVSDatabase {
     }
   }
 
+  private func _query(model: RequestTypeModel, key: String) -> Query {
+
+    var cvsList: [CVSType] = CVSType.allCases.dropLast()
+    var eventList: [EventType] = EventType.allCases.dropLast()
+    if model.cvs != .all {
+      cvsList = [model.cvs]
+    }
+    if model.event != .all {
+      eventList = [model.event]
+    }
+
+    let ref = self.database.document(key).collection(Name.item)
+      .whereField(Name.cvs, in: cvsList)
+      .whereField(Name.event, in: eventList)
+
+    if model.sort == .none {
+      return ref
+    }
+
+    return ref
+      .order(by: Name.price, descending: model.sort == .descending ? true : false)
+  }
+
   func informationTask(
     request: RequestTypeModel,
     offset: Int = 0,
@@ -61,6 +84,7 @@ final class CVSDatabase {
             throw Error.synchronized
           }
 
+          // ok. access to firebase
           observer(.success([]))
         } catch {
           observer(.failure(error))

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -23,7 +23,7 @@ final class CVSDatabase {
     return self._syncKey().asObservable()
   }
 
-  func informationTask(
+  func product(
     request: RequestTypeModel,
     offset: Int = 0,
     limit: Int = 10

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -39,24 +39,26 @@ final class CVSDatabase {
 
   private func _query(model: RequestTypeModel, key: String) -> Query {
 
-    var cvsList: [String] = CVSType.allCases.dropLast().map { $0.title }
-    var eventList: [String] = EventType.allCases.dropLast().map { $0.rawValue }
-    if model.cvs != .all {
-      cvsList = [model.cvs.title]
-    }
-    if model.event != .all {
-      eventList = [model.event.rawValue]
-    }
-
     let ref = self.database.document(key).collection(Name.item)
-      .whereField(Name.cvs, in: cvsList)
-      .whereField(Name.event, in: eventList)
+    var query: Query
+
+    if model.cvs != .all && model.event != .all {
+      query = ref
+        .whereField(Name.cvs, isEqualTo: model.cvs.title)
+        .whereField(Name.event, isEqualTo: model.event.rawValue)
+    } else if model.cvs != .all {
+      query = ref
+        .whereField(Name.cvs, isEqualTo: model.cvs.title)
+    } else {
+      query = ref
+        .whereField(Name.event, isEqualTo: model.event.rawValue)
+    }
 
     if model.sort == .none {
-      return ref
+      return query
     }
 
-    return ref
+    return query
       .order(by: Name.price, descending: model.sort == .descending ? true : false)
   }
 

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -19,10 +19,6 @@ final class CVSDatabase {
 
   private lazy var database: CollectionReference = Firestore.firestore().collection("sale")
 
-//  var isSynchronized: Bool {
-//    db.document("sync_key")
-//  }
-
 }
 
 // MARK: - Models and Constants
@@ -30,14 +26,14 @@ final class CVSDatabase {
 extension CVSDatabase {
 
   enum Error: Swift.Error {
-    
+
     /// Firebase를 읽어드리는 데 오류가 발생한 경우
     case firebase
-    
+
     /// 데이터가 잘못 들어와 디코딩이 되지 않는 경우
     /// 이는 서버측의 데이터타입 문제이거나, 해당 클래스의 타입변경 미스일 때 발생합니다.
     case decoding
-    
+
     /// 서버에 저장되어있는 데이터가 현재 날짜랑 맞지 않는 경우
     case synchronized
   }

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -62,6 +62,28 @@ final class CVSDatabase {
       .order(by: Name.price, descending: model.sort == .descending ? true : false)
   }
 
+  private func snapshot(query: Query, offset: Int) -> Single<QueryDocumentSnapshot> {
+    return Single.create { observer in
+
+      query.addSnapshotListener { snapshot, _ in
+        guard let snapshot = snapshot else {
+          observer(.failure(Error.retrieving))
+          return
+        }
+
+        guard let lastSnapshot = snapshot.documents.last else {
+          observer(.failure(Error.retrieving)) // collection is empty if first access
+          return
+        }
+
+        observer(.success(lastSnapshot))
+      }
+        .remove()
+
+      return Disposables.create()
+    }
+  }
+
   func informationTask(
     request: RequestTypeModel,
     offset: Int = 0,

--- a/PPAK_CVS/Sources/Managers/CVSDatabase.swift
+++ b/PPAK_CVS/Sources/Managers/CVSDatabase.swift
@@ -65,7 +65,7 @@ final class CVSDatabase {
   private func snapshot(query: Query, offset: Int) -> Single<QueryDocumentSnapshot> {
     return Single.create { observer in
 
-      query.addSnapshotListener { snapshot, _ in
+      let listener = query.addSnapshotListener { snapshot, _ in
         guard let snapshot = snapshot else {
           observer(.failure(Error.retrieving))
           return
@@ -78,9 +78,10 @@ final class CVSDatabase {
 
         observer(.success(lastSnapshot))
       }
-        .remove()
 
-      return Disposables.create()
+      return Disposables.create {
+        listener.remove()
+      }
     }
   }
 

--- a/PPAK_CVS/Sources/Models/ProductModel.swift
+++ b/PPAK_CVS/Sources/Models/ProductModel.swift
@@ -1,0 +1,29 @@
+//
+//  ProductModel.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2022/11/06.
+//
+
+import Foundation
+
+struct ProductModel: Codable {
+  /// 이미지 주소
+  let imageLink: String
+  /// 물품명
+  let name: String
+  /// 가격
+  let price: Int
+  /// 편의점 가게
+  let store: String
+  /// 할인종류
+  let saleType: EventType
+
+  enum CodingKeys: String, CodingKey {
+    case name
+    case price
+    case store
+    case imageLink = "img"
+    case saleType = "tag"
+  }
+}

--- a/PPAK_CVS/Sources/Models/ProductModel.swift
+++ b/PPAK_CVS/Sources/Models/ProductModel.swift
@@ -9,13 +9,13 @@ import Foundation
 
 struct ProductModel: Codable {
   /// 이미지 주소
-  let imageLink: String
+  let imageLink: String?
   /// 물품명
   let name: String
   /// 가격
   let price: Int
   /// 편의점 가게
-  let store: String
+  let store: CVSType
   /// 할인종류
   let saleType: EventType
 

--- a/PPAK_CVS/Sources/Models/RequestTypeModel.swift
+++ b/PPAK_CVS/Sources/Models/RequestTypeModel.swift
@@ -1,0 +1,15 @@
+//
+//  RequestTypeModel.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2022/11/08.
+//
+
+import Foundation
+
+
+struct RequestTypeModel {
+  let cvs: CVSType
+  let event: EventType
+  let sort: SortType
+}

--- a/PPAK_CVS/Sources/Models/RequestTypeModel.swift
+++ b/PPAK_CVS/Sources/Models/RequestTypeModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 struct RequestTypeModel {
   let cvs: CVSType
   let event: EventType

--- a/PPAK_CVS/Sources/Scenes/Common/TitleLogoView.swift
+++ b/PPAK_CVS/Sources/Scenes/Common/TitleLogoView.swift
@@ -29,7 +29,7 @@ final class TitleLogoView: UIView {
       $0.centerX.centerY.equalToSuperview()
     }
 
-    titleLabel.text = cvsType.title
+    titleLabel.text = cvsType.rawValue
     titleLabel.textColor = cvsType.fontColor
     titleLabel.backgroundColor = cvsType.bgColor
   }


### PR DESCRIPTION
## Features ✨

### 1. Firebase

- Firebase 라이브러리를 추가했습니다.
- GoogleInfo.plist를 설치하기위해 Bundle Identifier를 수정했습니다.
- GoogleInfo.plist가 공개되는 것을 막기 위해 gitignore를 수정했습니다.

### 2. CVSDatabase 구현

싱글톤 오브젝트 `shared`로 접근 가능하며, 직접 생성하여 사용하셔도 무방합니다.

```swift

CVSDatabase.shared // singleton object
CVSDatabase() // new instance
```

#### 2-1. syncKey

```swift
CVSDatabase.shared.syncKey // Observable<String>
```
현재 데이터베이스에 저장되어있는 할인행사에 대한 날짜입니다. 만약 2022년 11월의 행사내역을 갖고 있다면 `2022:11`을 emit합니다.

#### 2-2. product

```swift
let model: RequestTypeModel = RequestTypeModel(
  cvs: .cu,               // cu 편의점인데
  event: .twoPlusOne,     // 2+1인 제품
  sort: .none             // 정렬 상관없이
)
CVSDatabase.shared.product(request: model, offset: 10, limit: 20)
  .asDriver(onErrorJustReturn: [])
  .drive { product in
    // UI Codes...
  }
  .disposed(by: disposeBag)
```

RequestTypeModel을 이용하여 제품 리스트를 방출하는 `Observable`를 리턴합니다.
`offset`과 `limit` 파라미터로 Pagination을 편리하게 진행할 수 있습니다.
요청의 결과로 `[ProductModel]`을 emit합니다.


##### 2-2_01. RequestTypeModel

```swift
struct RequestTypeModel {
  let cvs: CVSType
  let event: EventType
  let sort: SortType
}
```

편의점, 행사, 정렬을 구성하는 `request model`


##### 2-2_02. ProductModel

```swift
struct ProductModel: Codable {
  /// 이미지 주소
  let imageLink: String?
  /// 물품명
  let name: String
  /// 가격
  let price: Int
  /// 편의점 가게
  let store: CVSType
  /// 할인종류
  let saleType: EventType
}
```
제품에 대한 정보를 담고있는 `response model`

> **Note**: ProductModel의 imageLink는  단지 이미지 주소만을 갖고있으므로 UIImage로 변환해서 사용하셔야합니다.

#### 2-3. Error Handling

```swift
  enum Error: Swift.Error {

    /// Firebase를 읽어드리는 데 오류가 발생한 경우
    case firebase

    /// 데이터가 잘못 들어와 디코딩이 되지 않는 경우
    /// 이는 서버측의 데이터타입 문제이거나, 해당 클래스의 타입변경 미스일 때 발생합니다.
    case decoding

    /// 서버에 저장되어있는 데이터가 현재 날짜랑 맞지 않는 경우
    case synchronized

    /// 문서를 찾지 못한 경우
    case retrieving
  }
```
product 호출에 실패하면 위 에러코드가 반환됩니다.
다만 Error는 `Swift.Error`값으로 리턴되기 때문에 **해당 enum 값으로 접근할 수 없습니다.** (이건 고민 좀 해봐야할 듯 싶어요)


### 3. etc

- CVSDatabase의 synckey 프로퍼티를 위해 date에서 년과 월을 가져올 수 있는 프로퍼티를 `Date+`에 추가하여 구현하였습니다.(https://github.com/iOS-PPAK/PPAK_CVS/commit/edbe4551010b9bb5e3336c7abfa97545c4e568e5 참조)
- ProductModel의 타입으로 Enum을 재사용하기위해 `CVSType`, `EventType`을 `Codable`, `rawValue`를 갖도록 수정하였습니다. 