### PR TITLE
[Feat] 찜목록 저장소 구현 

### DIFF
--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		E505D9EF28CF5B4A00EEFC65 /* HomeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E505D9EE28CF5B4A00EEFC65 /* HomeVC.swift */; };
 		E505D9F428CF5B4B00EEFC65 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E505D9F328CF5B4B00EEFC65 /* Assets.xcassets */; };
 		E505D9F728CF5B4B00EEFC65 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E505D9F528CF5B4B00EEFC65 /* LaunchScreen.storyboard */; };
+		E50F851229589AFB008B7052 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50F851129589AFB008B7052 /* Storage.swift */; };
 		E5103251290B4A0300D2F007 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5103250290B4A0300D2F007 /* UIView+.swift */; };
 		E51669F029338593006C9635 /* LoadingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51669EF29338593006C9635 /* LoadingCell.swift */; };
 		E5464305291F884900A9D87B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E5464304291F884900A9D87B /* GoogleService-Info.plist */; };
@@ -136,6 +137,7 @@
 		E505D9F328CF5B4B00EEFC65 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E505D9F628CF5B4B00EEFC65 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E505D9F828CF5B4B00EEFC65 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E50F851129589AFB008B7052 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		E5103250290B4A0300D2F007 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		E51669EF29338593006C9635 /* LoadingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingCell.swift; sourceTree = "<group>"; };
 		E5464304291F884900A9D87B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				BAA0F53428FD353500B632AC /* AppCoordinator.swift */,
 				E505D9EA28CF5B4A00EEFC65 /* AppDelegate.swift */,
 				E505D9EC28CF5B4A00EEFC65 /* SceneDelegate.swift */,
+				E50F851029589AEE008B7052 /* Storage */,
 				BAA21ACC29155A0F00056DB6 /* Network */,
 				A5932EA828E047B400457AD3 /* Models */,
 				E584487C28D55B9000E25265 /* Scenes */,
@@ -391,6 +394,14 @@
 				E505D9F828CF5B4B00EEFC65 /* Info.plist */,
 			);
 			path = PPAK_CVS;
+			sourceTree = "<group>";
+		};
+		E50F851029589AEE008B7052 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				E50F851129589AFB008B7052 /* Storage.swift */,
+			);
+			path = Storage;
 			sourceTree = "<group>";
 		};
 		E54D9C4028F1A16700D028B2 /* Bookmark */ = {
@@ -568,6 +579,7 @@
 				9C798F8A28EAE9DA00FE250C /* TitleLogoView.swift in Sources */,
 				9CA7150E293CE26300AEE436 /* NSAttributedString+.swift in Sources */,
 				BAEF774928F412FA006B0274 /* ProductCollectionHeaderView.swift in Sources */,
+				E50F851229589AFB008B7052 /* Storage.swift in Sources */,
 				BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */,
 				BAA21ACE29155E4A00056DB6 /* CVSDatabase.swift in Sources */,
 				E505D9EB28CF5B4A00EEFC65 /* AppDelegate.swift in Sources */,

--- a/PPAK_CVS/Sources/Models/ProductModel.swift
+++ b/PPAK_CVS/Sources/Models/ProductModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ProductModel: Codable {
+struct ProductModel: Codable, Equatable {
   /// 이미지 주소
   let imageLink: String?
   /// 물품명

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -41,16 +41,35 @@ final class Storage {
   func remove(_ target: ProductModel) {
     // TODO: 특정 아이템을 어떻게 삭제할까?
   }
-  
-  func search(_ target: String) -> [ProductModel] {
+
+  func retrieve(
+    cvs: CVSType = .all,
+    event: EventType = .all,
+    target: String?
+  ) -> [ProductModel] {
     var newProducts: [ProductModel] = []
     
-    for item in products {
-      if item.name.contains(target) {
-        newProducts.append(item)
+    if let target = target {
+      
+      for item in products {
+        if item.store == cvs,
+           item.saleType == event,
+           item.name.contains(target) {
+          newProducts.append(item)
+        }
+      }
+
+    } else {
+      
+      for item in products {
+        if item.store == cvs,
+           item.saleType == event {
+          newProducts.append(item)
+        }
       }
     }
     
     return newProducts
   }
+  
 }

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -45,31 +45,32 @@ final class Storage {
   func retrieve(
     cvs: CVSType = .all,
     event: EventType = .all,
+    sort: SortType = .none,
     target: String?
   ) -> [ProductModel] {
     var newProducts: [ProductModel] = []
     
-    if let target = target {
-      
-      for item in products {
-        if item.store == cvs,
-           item.saleType == event,
-           item.name.contains(target) {
-          newProducts.append(item)
+    newProducts = products
+      .filter {
+        if let target = target {
+          return $0.name.contains(target)
+        } else {
+          return true
         }
       }
-
-    } else {
-      
-      for item in products {
-        if item.store == cvs,
-           item.saleType == event {
-          newProducts.append(item)
+      .filter { $0.store == cvs }
+      .filter { $0.saleType == event }
+      .sorted {
+        switch sort {
+        case .ascending:
+          return $0.price < $1.price
+        case .descending:
+          return $0.price > $1.price
+        case .none:
+          return false
         }
       }
-    }
     
     return newProducts
   }
-  
 }

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -51,15 +51,9 @@ final class Storage {
     var newProducts: [ProductModel] = []
     
     newProducts = products
-      .filter {
-        if let target = target {
-          return $0.name.contains(target)
-        } else {
-          return true
-        }
-      }
-      .filter { $0.store == cvs }
-      .filter { $0.saleType == event }
+      .filter { target != nil ? $0.name.contains(target!) : true }
+      .filter { cvs == .all ? true : $0.store == cvs }
+      .filter { event == .all ? true : $0.saleType == event }
       .sorted {
         switch sort {
         case .ascending:

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -1,0 +1,56 @@
+//
+//  Storage.swift
+//  PPAK_CVS
+//
+//  Created by 김응철 on 2022/12/25.
+//
+
+import Foundation
+
+final class Storage {
+  
+  static let shared = Storage()
+  
+  private let key = "Storage"
+  private let userDefaults = UserDefaults.standard
+  private init() {}
+  
+  private(set) var products: [ProductModel] = shared.load() {
+    didSet {
+      let encoder = JSONEncoder()
+      if let encoded = try? encoder.encode(oldValue) {
+        userDefaults.set(encoded, forKey: key)
+      }
+    }
+  }
+  
+  func load() -> [ProductModel] {
+    guard let data = userDefaults.object(forKey: key) as? Data else { return [] }
+    let decoder = JSONDecoder()
+    if let products = try? decoder.decode([ProductModel].self, from: data) {
+      return products
+    } else {
+      return []
+    }
+  }
+  
+  func append(_ from: ProductModel) {
+    products.insert(from, at: 0)
+  }
+  
+  func remove(_ target: ProductModel) {
+    // TODO: 특정 아이템을 어떻게 삭제할까?
+  }
+  
+  func search(_ target: String) -> [ProductModel] {
+    var newProducts: [ProductModel] = []
+    
+    for item in products {
+      if item.name.contains(target) {
+        newProducts.append(item)
+      }
+    }
+    
+    return newProducts
+  }
+}

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -17,7 +17,7 @@ final class Storage {
   
   private(set) lazy var products: [ProductModel] = load() {
     didSet {
-      if let encoded = try? JSONEncoder().encode(oldValue) {
+      if let encoded = try? JSONEncoder().encode(products) {
         userDefaults.set(encoded, forKey: key)
       }
     }
@@ -43,12 +43,12 @@ final class Storage {
   func contains(_ from: ProductModel) -> Bool {
     return products.contains(from)
   }
-
+  
   func retrieve(
     cvs: CVSType = .all,
     event: EventType = .all,
     sort: SortType = .none,
-    target: String?
+    target: String? = nil
   ) -> [ProductModel] {
     var newProducts: [ProductModel] = []
     

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -15,19 +15,17 @@ final class Storage {
   private let userDefaults = UserDefaults.standard
   private init() {}
   
-  private(set) var products: [ProductModel] = shared.load() {
+  private(set) lazy var products: [ProductModel] = load() {
     didSet {
-      let encoder = JSONEncoder()
-      if let encoded = try? encoder.encode(oldValue) {
+      if let encoded = try? JSONEncoder().encode(oldValue) {
         userDefaults.set(encoded, forKey: key)
       }
     }
   }
   
-  func load() -> [ProductModel] {
+  private func load() -> [ProductModel] {
     guard let data = userDefaults.object(forKey: key) as? Data else { return [] }
-    let decoder = JSONDecoder()
-    if let products = try? decoder.decode([ProductModel].self, from: data) {
+    if let products = try? JSONDecoder().decode([ProductModel].self, from: data) {
       return products
     } else {
       return []
@@ -51,7 +49,7 @@ final class Storage {
     var newProducts: [ProductModel] = []
     
     newProducts = products
-      .filter { target != nil ? $0.name.contains(target!) : true }
+      .filter { target == nil ? true : $0.name.contains(target!) }
       .filter { cvs == .all ? true : $0.store == cvs }
       .filter { event == .all ? true : $0.saleType == event }
       .sorted {

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -34,7 +34,7 @@ final class Storage {
     }
   }
   
-  func append(_ from: ProductModel) {
+  func add(_ from: ProductModel) {
     products.insert(from, at: 0)
   }
   

--- a/PPAK_CVS/Sources/Storage/Storage.swift
+++ b/PPAK_CVS/Sources/Storage/Storage.swift
@@ -37,7 +37,11 @@ final class Storage {
   }
   
   func remove(_ target: ProductModel) {
-    // TODO: 특정 아이템을 어떻게 삭제할까?
+    products = products.filter { $0 != target }
+  }
+  
+  func contains(_ from: ProductModel) -> Bool {
+    return products.contains(from)
   }
 
   func retrieve(


### PR DESCRIPTION
## Features ✨

- `UserDefaults`를 이용한 찜목록을 관리할 수 있는 싱글톤 객체를 구현하였습니다.
- `ProductModel`의 고유식별자가 없는 관계로 `Delete`는 구현하지 못했습니다.
- Property observer를 이용하여 자동적으로 기기에 저장하도록 구현했습니다.
- `retrieve()`를 명령형 프로그래밍으로 구현해봤는데, 분기처리를 할 게 너무 많고 코드가 너무 길어지는 관계로 함수형 프로그래밍으로 구현했습니다.

---

특정 제품을 찜을 할 때, 고유식별자가 포함된 Model을 새로 만들어서 저장을 해줄까.. 라고 생각을 했지만
그렇게 되면 Home에서 이미 찜했던 제품을 선택하면, 찜이 된 제품인지 아닌지 판단할 수 없는 관계로 이 방법은 채택하지 못했습니다 ㅠㅠ..

## Screenshots 📸


## To Reviewers

<!-- - Firebase 테이블과 비교하면서 검토해주시고 리뷰해주세요!-->
