### PR TITLE
세부 제품 구현

### DIFF
--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
+		BAA1AAE72962AFAE00E763D1 /* ProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA1AAE62962AFAE00E763D1 /* ProductViewModel.swift */; };
 		BABC84B228F58F5A00D6DF45 /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABC84B128F58F5A00D6DF45 /* Preview.swift */; };
 		BAD70BD8291A58CB00C39863 /* SortType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD70BD7291A58CB00C39863 /* SortType.swift */; };
 		BAD70BDA291A594F00C39863 /* RequestTypeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD70BD9291A594F00C39863 /* RequestTypeModel.swift */; };
@@ -142,6 +143,7 @@
 		BAA0580F28D36F75000CDD11 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		BAA0F53428FD353500B632AC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		BAA1AAE62962AFAE00E763D1 /* ProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductViewModel.swift; sourceTree = "<group>"; };
 		BABC84B128F58F5A00D6DF45 /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		BAD70BD7291A58CB00C39863 /* SortType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortType.swift; sourceTree = "<group>"; };
 		BAD70BD9291A594F00C39863 /* RequestTypeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTypeModel.swift; sourceTree = "<group>"; };
@@ -378,6 +380,7 @@
 				BA5A433D28F2FF47008DCDCC /* ProductCoordinator.swift */,
 				BA8CF87B290D10CB009770C0 /* ProductHeaderViewViewModel.swift */,
 				BA5A433B28F2FF15008DCDCC /* ProductVC.swift */,
+				BAA1AAE62962AFAE00E763D1 /* ProductViewModel.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";
@@ -623,6 +626,7 @@
 				E505D9ED28CF5B4A00EEFC65 /* SceneDelegate.swift in Sources */,
 				E580BF2528E0649E00BE7ADC /* HomeCollectionHeaderView.swift in Sources */,
 				E580BF2328E0646200BE7ADC /* GoodsCell.swift in Sources */,
+				BAA1AAE72962AFAE00E763D1 /* ProductViewModel.swift in Sources */,
 				BA9EBC102949BBC600167970 /* TargetType.swift in Sources */,
 				E5B9965B28E2A16D00E39566 /* SortDropdownView.swift in Sources */,
 				BA8CF87C290D10CB009770C0 /* ProductHeaderViewViewModel.swift in Sources */,

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		BA27024428CF60A30039D9EA /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BA27024328CF60A30039D9EA /* RxSwift */; };
 		BA27024728CF61020039D9EA /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = BA27024628CF61020039D9EA /* Kingfisher */; };
 		BA27024928CF618E0039D9EA /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA27024828CF618E0039D9EA /* HomeCoordinator.swift */; };
+		BA343AB12963139900DE8016 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA343AB02963139900DE8016 /* Int+.swift */; };
 		BA5A433C28F2FF15008DCDCC /* ProductVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5A433B28F2FF15008DCDCC /* ProductVC.swift */; };
 		BA5A433E28F2FF47008DCDCC /* ProductCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5A433D28F2FF47008DCDCC /* ProductCoordinator.swift */; };
 		BA8CF87C290D10CB009770C0 /* ProductHeaderViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8CF87B290D10CB009770C0 /* ProductHeaderViewViewModel.swift */; };
@@ -128,6 +129,7 @@
 		BA1CCACC28FB9A450002FD8C /* Viewable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Viewable.swift; sourceTree = "<group>"; };
 		BA27023028CF5DCD0039D9EA /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BA27024828CF618E0039D9EA /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
+		BA343AB02963139900DE8016 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		BA5A433B28F2FF15008DCDCC /* ProductVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVC.swift; sourceTree = "<group>"; };
 		BA5A433D28F2FF47008DCDCC /* ProductCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCoordinator.swift; sourceTree = "<group>"; };
 		BA8CF87B290D10CB009770C0 /* ProductHeaderViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductHeaderViewViewModel.swift; sourceTree = "<group>"; };
@@ -283,15 +285,16 @@
 		A5F8288828DEC09B00C5D6A2 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				BA9EDA9C2918BF8F00B97C23 /* Date+.swift */,
 				BA9EBC15294A04E500167970 /* Encodable+.swift */,
+				BA9EDA9C2918BF8F00B97C23 /* Date+.swift */,
+				BA343AB02963139900DE8016 /* Int+.swift */,
+				9CA7150D293CE26300AEE436 /* NSAttributedString+.swift */,
+				BABC84B128F58F5A00D6DF45 /* Preview.swift */,
 				A5F8288928DEC0CF00C5D6A2 /* UIButton+.swift */,
-				A5F8288D28DED76700C5D6A2 /* UILabel+.swift */,
 				BA8CFD7C28E1E4AB00ADC4A8 /* UIColor+.swift */,
 				A5B69C3B29600A1000052D2B /* UIFont+.swift */,
+				A5F8288D28DED76700C5D6A2 /* UILabel+.swift */,
 				E5103250290B4A0300D2F007 /* UIView+.swift */,
-				BABC84B128F58F5A00D6DF45 /* Preview.swift */,
-				9CA7150D293CE26300AEE436 /* NSAttributedString+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -611,6 +614,7 @@
 				9C07AE832934D763002CFE3F /* SettingTableViewCell.swift in Sources */,
 				E5A877C028D4A34D002A2402 /* PageControl.swift in Sources */,
 				E5B9965728E2872A00E39566 /* CVSDropdownView.swift in Sources */,
+				BA343AB12963139900DE8016 /* Int+.swift in Sources */,
 				BAD70BDA291A594F00C39863 /* RequestTypeModel.swift in Sources */,
 				BA27024928CF618E0039D9EA /* HomeCoordinator.swift in Sources */,
 				BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */,

--- a/PPAK_CVS/Configuration/Extensions/Int+.swift
+++ b/PPAK_CVS/Configuration/Extensions/Int+.swift
@@ -1,0 +1,16 @@
+//
+//  Int+.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2023/01/02.
+//
+
+import Foundation
+
+extension Int {
+  var commaRepresentation: String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    return formatter.string(from: NSNumber(value: self)) ?? ""
+  }
+}

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import RxSwift
 import RxCocoa
 import SnapKit
@@ -25,7 +26,6 @@ final class ProductCollectionHeaderView: UICollectionReusableView, Viewable {
 
   private let productImageView = UIImageView().then {
     $0.contentMode = .scaleAspectFit
-    $0.backgroundColor = .systemBlue // temporary color
   }
 
   private let nameLabel = UILabel().then {
@@ -57,7 +57,7 @@ final class ProductCollectionHeaderView: UICollectionReusableView, Viewable {
 
   private let wholeStackView = UIStackView().then {
     $0.alignment = .center
-    $0.distribution = .fillProportionally
+    $0.distribution = .fill
     $0.axis = .vertical
     $0.spacing = 10
   }
@@ -141,6 +141,18 @@ extension ProductCollectionHeaderView {
       .map { ViewModel.Action.share($0) }
       .bind(to: viewModel.action)
       .disposed(by: disposeBag)
+  }
+
+  func configureUI(with model: ProductModel) {
+    let discount = model.saleType == .onePlusOne ? 2 : 3
+
+    nameLabel.text = model.name
+    priceLabel.text = "\(model.price.commaRepresentation)원"
+    priceDiscriptionLabel.text = "(개당 \(Int(model.price / discount).commaRepresentation)원)"
+
+    productImageView.kf.setImage(with: URL(string: model.imageLink ?? ""))
+
+    curveView.backgroundColor = model.store.bgColor
   }
 }
 

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
@@ -145,10 +145,11 @@ extension ProductCollectionHeaderView {
 
   func configureUI(with model: ProductModel) {
     let discount = model.saleType == .onePlusOne ? 2 : 3
+    let multiply = model.saleType == .onePlusOne ? 1 : 2
 
     nameLabel.text = model.name
     priceLabel.text = "\(model.price.commaRepresentation)원"
-    priceDiscriptionLabel.text = "(개당 \(Int(model.price / discount).commaRepresentation)원)"
+    priceDiscriptionLabel.text = "(개당 \(Int(model.price / discount * multiply).commaRepresentation)원)"
 
     productImageView.kf.setImage(with: URL(string: model.imageLink ?? ""))
 

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
@@ -11,7 +11,9 @@ final class ProductCoordinator: BaseCoordinator {
 
   override func start() {
     let viewController = ProductViewController()
+    let viewModel = ProductViewModel()
     viewController.coordinator = self
+    viewController.viewModel = viewModel
     self.navigationController.pushViewController(viewController, animated: true)
   }
 }

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
@@ -9,6 +9,25 @@ import UIKit
 
 final class ProductCoordinator: BaseCoordinator {
 
+  // MARK: - Properties
+
+  private let model: ProductModel
+  private let disposeBag = DisposeBag()
+
+  // MARK: - Initializations
+
+  init(_ navigationController: UINavigationController, model: ProductModel) {
+    self.model = model
+    super.init(navigationController: navigationController)
+  }
+
+  private override init(navigationController: UINavigationController) {
+    self.model = ProductModel(imageLink: "", name: "", price: 0, store: .all, saleType: .all)
+    super.init(navigationController: navigationController)
+  }
+
+  // MARK: - Coordinator functions
+
   override func start() {
     let viewController = ProductViewController()
     let viewModel = ProductViewModel()

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
+
 final class ProductCoordinator: BaseCoordinator {
 
   // MARK: - Properties
@@ -34,5 +37,12 @@ final class ProductCoordinator: BaseCoordinator {
     viewController.coordinator = self
     viewController.viewModel = viewModel
     self.navigationController.pushViewController(viewController, animated: true)
+    bind(viewModel)
+  }
+
+  private func bind(_ viewModel: ProductViewModel) {
+    Observable<ProductViewModel.Action>.just(.updateProduct(self.model))
+      .bind(to: viewModel.action)
+      .disposed(by: disposeBag)
   }
 }

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -12,7 +12,7 @@ import RxCocoa
 import SnapKit
 import Then
 
-final class ProductViewController: BaseViewController {
+final class ProductViewController: BaseViewController, Viewable {
 
   private lazy var collectionView = UICollectionView(
     frame: .zero,
@@ -71,6 +71,10 @@ final class ProductViewController: BaseViewController {
     collectionView.snp.makeConstraints { make in
       make.edges.equalTo(view.safeAreaLayoutGuide)
     }
+  }
+
+  func bind(viewModel: ProductViewModel) {
+
   }
 
   func bind(_ headerView: ProductCollectionHeaderView) {

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -39,8 +39,11 @@ final class ProductViewController: BaseViewController, Viewable {
       guard let newValue = newValue else { return }
       newValue.viewModel = ProductHeaderViewViewModel()
       bind(newValue)
+      self.headerViewInitializeRelay.accept(newValue)
     }
   }
+
+  private let headerViewInitializeRelay = PublishRelay<ProductCollectionHeaderView>()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -75,6 +78,15 @@ final class ProductViewController: BaseViewController, Viewable {
 
   func bind(viewModel: ProductViewModel) {
 
+    let modelObservable = viewModel.state.map { $0.model }
+    let headerViewObservable = headerViewInitializeRelay.asObservable()
+
+    Observable.combineLatest(modelObservable, headerViewObservable)
+      .subscribe(onNext: { [weak self] model, headerView in
+        headerView.configureUI(with: model)
+        self?.collectionView.backgroundColor = model.store.bgColor
+      })
+      .disposed(by: disposeBag)
   }
 
   func bind(_ headerView: ProductCollectionHeaderView) {

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -23,7 +23,7 @@ final class ProductViewController: BaseViewController {
       layout.itemSize = CGSize(width: self.view.bounds.width, height: 125)
       layout.sectionInset = UIEdgeInsets(top: 24, left: 0, bottom: 16, right: 0)
     }
-    $0.contentInsetAdjustmentBehavior = .never
+    $0.bounces = false
     $0.register(GoodsCell.self, forCellWithReuseIdentifier: GoodsCell.id)
     $0.register(
       ProductCollectionHeaderView.self,
@@ -131,3 +131,12 @@ extension ProductViewController: UICollectionViewDataSource {
     return headerView
   }
 }
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+struct ProductViewControllerPreview: PreviewProvider {
+  static var previews: some View {
+    ProductViewController().toPreview()
+  }
+}
+#endif

--- a/PPAK_CVS/Sources/Scenes/Product/ProductViewModel.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductViewModel.swift
@@ -5,19 +5,40 @@
 //  Created by 홍승현 on 2023/01/02.
 //
 
+import RxSwift
+import RxCocoa
+
 final class ProductViewModel: ViewModel {
 
   enum Action {
-
+    case updateProduct(ProductModel)
   }
 
   enum Mutation {
-
+    case updateProduct(ProductModel)
   }
 
   struct State {
-
+    var model = ProductModel(imageLink: "", name: "", price: 0, store: .all, saleType: .all)
   }
 
   var initialState = State()
+
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .updateProduct(let model):
+      return .just(.updateProduct(model))
+    }
+  }
+
+  func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+
+    switch mutation {
+    case .updateProduct(let model):
+      newState.model = model
+    }
+
+    return newState
+  }
 }

--- a/PPAK_CVS/Sources/Scenes/Product/ProductViewModel.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  ProductViewModel.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2023/01/02.
+//
+
+final class ProductViewModel: ViewModel {
+
+  enum Action {
+
+  }
+
+  enum Mutation {
+
+  }
+
+  struct State {
+
+  }
+
+  var initialState = State()
+}


### PR DESCRIPTION
## Features ✨

`ProductModel`에 따라 제품의 정보를 보여지도록 UI를 구현했습니다.


## Screenshots 📸

https://user-images.githubusercontent.com/57972338/210258985-ae1d3bff-025c-42e1-9478-6d9862257ac7.MP4

## To Reviewers

제품 정보를 받아야 UI를 업데이트할 수 있기 때문에, coordinator에서 ProductModel을 제공해주어야합니다.
따라서 기존의 init이 아닌 새로운 init을 추가하여 다음과 같이 코드를 구현했습니다.
```swift
  init(_ navigationController: UINavigationController, model: ProductModel) {
    self.model = model
    super.init(navigationController: navigationController)
  }

  private override init(navigationController: UINavigationController) {
    self.model = ProductModel(imageLink: "", name: "", price: 0, store: .all, saleType: .all)
    super.init(navigationController: navigationController)
  }
```

Coordinator를 생성하고 호출하고싶다면 다음과 같이 하시면 됩니다.

```swift
// ❌ Error!
let coordinator = ProductCoordinator(navigationController: self.navigationController)

// ✅ ok
let product: ProductModel = ...
let coordinator = ProductCoordinator(self.navigationController, model: product)
self.start(childCoordinator: coordinator)
```


P.S. : 폰트 및 색상같은 Style 설정은 이번 PR에서 구현하지 않았습니다. 다음 PR 때 구현 예정입니다 :)