### PR TITLE
Home Pagination 버그 수정 

### DIFF
--- a/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
+++ b/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
@@ -58,6 +58,7 @@ final class GoodsCell: UICollectionViewCell {
 
   override init(frame: CGRect) {
     super.init(frame: frame)
+    setupStyles()
     setupLayouts()
     setupConstraints()
   }
@@ -67,6 +68,10 @@ final class GoodsCell: UICollectionViewCell {
   }
 
   // MARK: - Setup
+
+  private func setupStyles() {
+    contentView.isUserInteractionEnabled = true
+  }
 
   private func setupLayouts() {
     [containerView, titleLogoView]

--- a/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
+++ b/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
@@ -69,9 +69,7 @@ final class GoodsCell: UICollectionViewCell {
 
   // MARK: - Setup
 
-  private func setupStyles() {
-    contentView.isUserInteractionEnabled = true
-  }
+  private func setupStyles() {}
 
   private func setupLayouts() {
     [containerView, titleLogoView]

--- a/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
+++ b/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
@@ -101,6 +101,7 @@ final class GoodsCell: UICollectionViewCell {
     stackView.snp.makeConstraints { make in
       make.centerY.equalToSuperview()
       make.leading.equalTo(goodsImage.snp.trailing).offset(8.0)
+      make.trailing.equalToSuperview().inset(16)
     }
   }
 }

--- a/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
@@ -199,7 +199,10 @@ final class HomeViewController: BaseViewController, Viewable {
 // MARK: - CollectionView Setup
 
 extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
 
     guard let currentState = viewModel?.currentState else {
       return UICollectionViewCell()
@@ -283,8 +286,8 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
   ) {
     guard let viewModel = viewModel else { return }
 
-    if indexPath.row == viewModel.currentState.products.count,
-       !viewModel.currentState.isBlockedRequest,
+    if indexPath.row == viewModel.currentState.products.count &&
+       !viewModel.currentState.isBlockedRequest &&
        !viewModel.currentState.isPagination {
       viewModel.action.onNext(.fetchMoreData)
     }

--- a/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
@@ -136,7 +136,7 @@ final class HomeViewController: BaseViewController, Viewable {
       .map { HomeViewModel.Action.didChangeSearchBar($0) }
       .bind(to: viewModel.action)
       .disposed(by: disposeBag)
-    
+
     // 빈공간 터치 감지
     // FIXME: 방식 바꿔야함
     view.rx.tapGesture(configuration: { _, delegate in
@@ -207,18 +207,18 @@ final class HomeViewController: BaseViewController, Viewable {
 extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
 
-    guard let products = viewModel?.currentState.products else {
+    guard let currentState = viewModel?.currentState else {
       return UICollectionViewCell()
     }
 
-    if indexPath.row != products.count {
+    if indexPath.row != currentState.products.count {
       guard let cell = collectionView.dequeueReusableCell(
         withReuseIdentifier: GoodsCell.id,
         for: indexPath
       ) as? GoodsCell else {
         return UICollectionViewCell()
       }
-      cell.updateCell(products[indexPath.row])
+      cell.updateCell(currentState.products[indexPath.row])
 
       return cell
     } else {
@@ -228,7 +228,12 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
       ) as? LoadingCell else {
         return UICollectionViewCell()
       }
-      cell.indicator.startAnimating()
+      
+      if currentState.isBlockedRequest {
+        cell.indicator.stopAnimating()
+      } else {
+        cell.indicator.startAnimating()
+      }
 
       return cell
     }
@@ -273,7 +278,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
     } else {
       height = indexPath.row == currentState.products.count ? 40 : 125
     }
-    
+
     return CGSize(width: width, height: height)
   }
 

--- a/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
@@ -139,7 +139,7 @@ final class HomeViewController: BaseViewController, Viewable {
       .disposed(by: disposeBag)
 
     // MARK: - State
-    
+
     // 편의점 로고 드롭다운 애니메이션 동작
     viewModel.state
       .map { $0.isVisibleCVSDropdown }
@@ -240,7 +240,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
     guard let products = viewModel?.currentState.products else { return 0 }
     return products.count > 0 ? products.count + 1 : 0
   }
-  
+
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
@@ -315,7 +315,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
     didSelectItemAt indexPath: IndexPath
   ) {
   }
-  
+
   func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
     cvsDropdownView.willDisappearDropdown()
     sortDropdownView.willDisappearDropdown()

--- a/PPAK_CVS/Sources/Scenes/Home/HomeViewModel.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeViewModel.swift
@@ -54,7 +54,7 @@ final class HomeViewModel: ViewModel {
     switch action {
     case .viewDidLoad:
       return requestProducts(cvs: .all, event: .all, sort: .none)
-      
+
     case .fetchMoreData:
       let nextOffset = currentState.currentOffset + 20
       return .concat([

--- a/PPAK_CVS/Sources/Scenes/Home/HomeViewModel.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeViewModel.swift
@@ -7,7 +7,6 @@ final class HomeViewModel: ViewModel {
     case viewDidLoad
     case currentCVSButtonDidTap
     case filterButtonDidTap
-    case backgroundDidTap
     case bookmarkButtonDidTap
     case pageControlIndexDidChange(EventType)
     case dropdownCVSButtonDidTap(CVSDropdownCase)
@@ -17,8 +16,8 @@ final class HomeViewModel: ViewModel {
   }
 
   enum Mutation {
-    case toggleCVSDropdown
-    case toggleFilterDropdown
+    case setCVSDropdown(Bool)
+    case setFilterDropdown(Bool)
     case toggleShowBookmarkVC(Bool)
     case hideDropdown
     case setCVS(CVSType)
@@ -55,7 +54,7 @@ final class HomeViewModel: ViewModel {
     switch action {
     case .viewDidLoad:
       return requestProducts(cvs: .all, event: .all, sort: .none)
-
+      
     case .fetchMoreData:
       let nextOffset = currentState.currentOffset + 20
       return .concat([
@@ -72,13 +71,18 @@ final class HomeViewModel: ViewModel {
       ])
 
     case .currentCVSButtonDidTap:
-      return .just(.toggleCVSDropdown)
+      let isVisible = currentState.isVisibleCVSDropdown
+      return .concat([
+        .just(.setCVSDropdown(!isVisible)),
+        .just(.setFilterDropdown(false))
+      ])
 
     case .filterButtonDidTap:
-      return .just(.toggleFilterDropdown)
-
-    case .backgroundDidTap:
-      return .just(.hideDropdown)
+      let isVisible = currentState.isVisibleFilterDropdown
+      return .concat([
+        .just(.setFilterDropdown(!isVisible)),
+        .just(.setCVSDropdown(false))
+      ])
 
     case .bookmarkButtonDidTap:
       guard currentState.showBookmarkVC == false else { return .empty() }
@@ -93,6 +97,7 @@ final class HomeViewModel: ViewModel {
         .just(.setEvent(event)),
         .just(.resetProducts),
         .just(.resetOffset),
+        .just(.hideDropdown),
         requestProducts(
           cvs: currentState.currentCVSType,
           event: event,
@@ -143,6 +148,7 @@ final class HomeViewModel: ViewModel {
         .just(.resetProducts),
         .just(.resetOffset),
         .just(.setTarget(target)),
+        .just(.hideDropdown),
         requestProducts(
           cvs: currentState.currentCVSType,
           event: currentState.currentEventType,
@@ -166,11 +172,11 @@ final class HomeViewModel: ViewModel {
     case .setLoading(let isLoading):
       nextState.isLoading = isLoading
 
-    case .toggleCVSDropdown:
-      nextState.isVisibleCVSDropdown.toggle()
+    case .setCVSDropdown(let isVisible):
+      nextState.isVisibleCVSDropdown = isVisible
 
-    case .toggleFilterDropdown:
-      nextState.isVisibleFilterDropdown.toggle()
+    case .setFilterDropdown(let isVisible):
+      nextState.isVisibleFilterDropdown = isVisible
 
     case .hideDropdown:
       nextState.isVisibleFilterDropdown = false


### PR DESCRIPTION
## Features ✨

### ISSUE 1
**이전에 상품 목록을 불러오면, 더 이상 불러올 상품이 없음에도 불구하고 인디케이터가 계속 작동하는 버그가 있었습니다.**
### ISSUE2
**RxGesture를 통해서 백그라운드 터치를 할 떄, 키보드를 dismiss하는 로직을 구현을 했었는데 셀의 터치가 작동하지 않는 버그가 있었습니다.**

---

### ISSUE 1 Solution
- HomeViewModel State의 Bool타입의 변수 2가지를 넣어서 각 상황마다 다르게 구현을 했습니다. `isPagination`, `isBlockedRequest`
- `isPagination`은 하단 스크롤을 통해 네트워크 작업이 진행되는 동안 `false` -> `true`로 값이 변합니다.
- `isBlockedRequest`은 API를 통해 StatusCode가 `400`일 경우에 `false` -> `true`로 값이 변합니다.

### ISSUE 2 Solution
- 백그라운드의 터치 이벤트를 받지 않고 CollectionView를 드래그 하기 시작하거나, 다른 Component의 터치 이벤트가 발생했을 때, `endEditing`과 드롭다운들이 `hide`되도록 구현했습니다.

## Screenshots 📸



## To Reviewers

+ 지금까지 테스트 해본 결과 잘 작동하지만, 아직 제가 모르는 경우의 수가 있을 수도 있습니다.
+ 그런 경우가 나중에 발생한다면 다시 수정하도록 하겠습니다 ! 

<!-- - Firebase 테이블과 비교하면서 검토해주시고 리뷰해주세요!-->
