### PR TITLE
SettingVC - 리뷰기능 추가 및 테이블뷰 UI수정

### DIFF
--- a/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
@@ -19,6 +19,6 @@ struct Message {
 
 struct Configs {
 
-  static let appID = "id362057947"
+  static let appID = "id1665633509"
   static let appStoreMailURL = "https://apps.apple.com/kr/app/mail/id1108187098"
   }

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
@@ -19,5 +19,6 @@ struct Message {
 
 struct Configs {
 
-  static let appStoreURL = "https://apps.apple.com/kr/app/mail/id362057947"
-}
+  static let appID = "id362057947"
+  static let appStoreURL = "https://apps.apple.com/kr/app/mail/\(appID)"
+  }

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
@@ -20,5 +20,5 @@ struct Message {
 struct Configs {
 
   static let appID = "id362057947"
-  static let appStoreURL = "https://apps.apple.com/kr/app/mail/\(appID)"
+  static let appStoreMailURL = "https://apps.apple.com/kr/app/mail/id1108187098"
   }

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingConfig.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Message {
 
   static let sendMailFail = "메일을 보낼 수 없습니다."
-  static let retry = "계정을 확인하고 다시 시도해주세요."
+  static let retry = "메일을 보내려면 'Mail' 앱이 필요합니다.\nApp Store에서 해당 앱을 복원하거나 이메일 설정을 확인하고 다시 시도해주세요."
   static let email = "bang.hyeonseok.dev@gmail.com"
 
   static let cancel = "취소"

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
@@ -124,7 +124,7 @@ extension SettingViewController: UITableViewDataSource, UITableViewDelegate {
       print("click: \(indexPath.row)")
     case 2:
       // 리뷰남기기
-      print("click: \(indexPath.row)")
+      requestReview()
     case 3:
       // 문의하기
       sendMail()

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
@@ -126,15 +126,18 @@ extension SettingViewController: UITableViewDataSource, UITableViewDelegate {
     case 0:
       // 푸시설정
       moveToSystemSetting()
+      print("click: \(indexPath.row)")
     case 1:
       // 공지사항
       print("click: \(indexPath.row)")
     case 2:
       // 리뷰남기기
       requestReview()
+      print("click: \(indexPath.row)")
     case 3:
       // 문의하기
       sendMail()
+      print("click: \(indexPath.row)")
     case 4:
       // 개발자 응원학
       print("click: \(indexPath.row)")

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
@@ -185,7 +185,7 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
   // TODO: 앱스토어 링크 수정필요
   /// 앱스토어로 이동시키는 함수
   private func moveToAppStore() {
-    if let url = URL(string: Configs.appStoreURL),
+    if let url = URL(string: Configs.appStoreMailURL),
         UIApplication.shared.canOpenURL(url) {
       if #available(iOS 10.0, *) {
         UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
@@ -107,6 +107,12 @@ extension SettingViewController: UITableViewDataSource, UITableViewDelegate {
     cell.iconImage.image = settingValue?.image
     cell.setDetail(indexPath.row)
     cell.selectionStyle = .none
+
+    // 민지님 요청으로 클릭제한처리
+    if indexPath.row == 2 {
+      cell.isUserInteractionEnabled = false
+    }
+
     return cell
   }
 

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
@@ -106,6 +106,7 @@ extension SettingViewController: UITableViewDataSource, UITableViewDelegate {
     cell.titleLabel.text = settingValue?.description
     cell.iconImage.image = settingValue?.image
     cell.setDetail(indexPath.row)
+    cell.selectionStyle = .none
     return cell
   }
 

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
@@ -245,3 +245,14 @@ extension SettingViewController: MFMailComposeViewControllerDelegate {
     }
   }
 }
+
+// MARK: RequestReview
+
+extension SettingViewController {
+
+  func requestReview() {
+    guard let writeReviewURL = URL(string: "https://apps.apple.com/app/\(Configs.appID)?action=write-review")
+        else { fatalError("Expected a valid URL") }
+    UIApplication.shared.open(writeReviewURL, options: [:], completionHandler: nil)
+  }
+}

--- a/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Setting/SettingVC.swift
@@ -39,6 +39,7 @@ final class SettingViewController: BaseViewController, Viewable {
     super.setupStyles()
     view.backgroundColor = .white
     setGesture()
+    tableView.separatorStyle = .none
   }
 
   override func setupLayouts() {


### PR DESCRIPTION
## Features ✨
- 리뷰기능 추가
- 앱아이디 분리 : 앱아이디는 메일 및 앱평가에 들어갈 앱스토어id값입니다 .현재 카카오로 하드코딩 되어있습니다.

기타요청사항
- 테이블뷰 구분선 none처리
- 리뷰기능 클릭제한처리 : 민지님께서 현재는 클릭제한해달라고 하셔서 제한했습니다, 영상시연을위해 영상에서는 클릭허용했습니다

## Screenshots 📸

https://user-images.githubusercontent.com/76529148/213439581-0373efa0-6a42-4e32-b599-f4a8d416f472.mov

