### PR TITLE
ProductVC UI 구현

### DIFF
--- a/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkVC.swift
@@ -232,7 +232,7 @@ extension BookmarkViewController: UICollectionViewDataSource, UICollectionViewDe
     ) as? GoodsCell else {
       return UICollectionViewCell()
     }
-    cell.updateCell(products[indexPath.row], showTitleLogoView: true)
+    cell.updateCell(products[indexPath.row], isShowTitleLogoView: true)
 
     return cell
   }

--- a/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkVC.swift
@@ -232,7 +232,7 @@ extension BookmarkViewController: UICollectionViewDataSource, UICollectionViewDe
     ) as? GoodsCell else {
       return UICollectionViewCell()
     }
-    cell.updateCell(products[indexPath.row])
+    cell.updateCell(products[indexPath.row], showTitleLogoView: true)
 
     return cell
   }

--- a/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
+++ b/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
@@ -105,11 +105,18 @@ final class GoodsCell: UICollectionViewCell {
 
 extension GoodsCell {
   /// 명시적으로 호출해야 합니다.
-  func updateCell(_ product: ProductModel) {
+  func updateCell(_ product: ProductModel, showTitleLogoView: Bool) {
     goodsLabel.text = product.name
-    priceLabel.text = "\(product.price)원"
+    
+    let discount = product.saleType == .onePlusOne ? 2 : 3
+    let multiply = product.saleType == .onePlusOne ? 1 : 2
+    let unitPrice = Int(product.price / discount * multiply).commaRepresentation
+    priceLabel.text = "\(product.price.commaRepresentation)원(개당 \(unitPrice)원)"
+    
     saleTypeView.updateStyles(product)
-    titleLogoView.updateStyles(product)
+    if showTitleLogoView {
+      titleLogoView.updateStyles(product)
+    }
 
     goodsImage.kf.setImage(
       with: URL(string: product.imageLink ?? ""),

--- a/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
+++ b/PPAK_CVS/Sources/Scenes/Common/GoodsCell.swift
@@ -105,7 +105,7 @@ final class GoodsCell: UICollectionViewCell {
 
 extension GoodsCell {
   /// 명시적으로 호출해야 합니다.
-  func updateCell(_ product: ProductModel, showTitleLogoView: Bool) {
+  func updateCell(_ product: ProductModel, isShowTitleLogoView: Bool) {
     goodsLabel.text = product.name
     
     let discount = product.saleType == .onePlusOne ? 2 : 3
@@ -114,7 +114,7 @@ extension GoodsCell {
     priceLabel.text = "\(product.price.commaRepresentation)원(개당 \(unitPrice)원)"
     
     saleTypeView.updateStyles(product)
-    if showTitleLogoView {
+    if isShowTitleLogoView {
       titleLogoView.updateStyles(product)
     }
 

--- a/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
@@ -218,7 +218,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
       ) as? GoodsCell else {
         return UICollectionViewCell()
       }
-      cell.updateCell(currentState.products[indexPath.row])
+      cell.updateCell(currentState.products[indexPath.row], showTitleLogoView: true)
 
       return cell
     } else {

--- a/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeVC.swift
@@ -218,7 +218,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
       ) as? GoodsCell else {
         return UICollectionViewCell()
       }
-      cell.updateCell(currentState.products[indexPath.row], showTitleLogoView: true)
+      cell.updateCell(currentState.products[indexPath.row], isShowTitleLogoView: true)
 
       return cell
     } else {

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
@@ -31,6 +31,15 @@ final class ProductCollectionHeaderView: UICollectionReusableView, Viewable {
     $0.font = Font.priceLabel
     $0.text = "1,500원"
   }
+  
+  private let badgeStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.distribution = .fill
+    $0.spacing = 10
+  }
+  
+  private let titleLogoView = TitleLogoView(cvsType: .all)
+  private let saleTypeView = SaleTypeView(cvsType: .all)
 
   private let previousHistoryLabel = UILabel().then {
     $0.font = Font.previousHistoryLabel
@@ -72,8 +81,12 @@ extension ProductCollectionHeaderView {
     }
 
     // == stackViews ==
-    [productImageView, nameLabel, priceLabel].forEach {
+    [productImageView, nameLabel, priceLabel, badgeStackView].forEach {
       wholeStackView.addArrangedSubview($0)
+    }
+    
+    [titleLogoView, saleTypeView].forEach {
+      badgeStackView.addArrangedSubview($0)
     }
 
     // == curveView ==
@@ -94,6 +107,11 @@ extension ProductCollectionHeaderView {
     productImageView.snp.makeConstraints { make in
       make.size.equalTo(150)
     }
+    
+    saleTypeView.snp.makeConstraints { make in
+      make.width.equalTo(45)
+      make.height.equalTo(20)
+    }
 
     previousHistoryLabel.snp.makeConstraints { make in
       make.bottom.trailing.equalToSuperview().inset(Inset.previousHistoryLabel)
@@ -103,7 +121,8 @@ extension ProductCollectionHeaderView {
   }
 
   private func setupStyles() {
-    backgroundColor = .systemBackground
+    backgroundColor = .white
+    wholeStackView.setCustomSpacing(16, after: productImageView)
   }
 
   func bind(viewModel: ProductHeaderViewViewModel) {
@@ -118,6 +137,9 @@ extension ProductCollectionHeaderView {
 
     nameLabel.text = model.name
     priceLabel.text = "\(model.price.commaRepresentation)원(개당 \(unitPrice)원)"
+    
+    titleLogoView.updateStyles(model)
+    saleTypeView.updateStyles(model)
 
     productImageView.kf.setImage(with: URL(string: model.imageLink ?? ""))
 

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -13,6 +13,9 @@ import SnapKit
 import Then
 
 final class ProductViewController: BaseViewController, Viewable {
+  
+  // test data (will delete)
+  private var previousHistory: [ProductModel] = []
 
   private let navigationHeaderBarView = UIView().then {
     $0.backgroundColor = .white
@@ -41,7 +44,7 @@ final class ProductViewController: BaseViewController, Viewable {
     $0.collectionViewLayout = UICollectionViewFlowLayout().then { layout in
       layout.headerReferenceSize = CGSize(width: view.bounds.width, height: 404)
       layout.itemSize = CGSize(width: self.view.bounds.width, height: 125)
-      layout.sectionInset = UIEdgeInsets(top: 24, left: 0, bottom: 16, right: 0)
+      layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0)
     }
     $0.bounces = false
     $0.register(GoodsCell.self, forCellWithReuseIdentifier: GoodsCell.id)
@@ -129,6 +132,38 @@ final class ProductViewController: BaseViewController, Viewable {
     Observable.combineLatest(modelObservable, headerViewObservable)
       .subscribe(onNext: { [weak self] model, headerView in
         headerView.configureUI(with: model)
+        
+        // --- test data(will delete) ---
+        self?.previousHistory.append(
+          ProductModel(
+            imageLink: model.imageLink,
+            name: "2022년 12월 행사 가격",
+            price: model.price,
+            store: model.store,
+            saleType: model.saleType
+          )
+        )
+        self?.previousHistory.append(
+          ProductModel(
+            imageLink: model.imageLink,
+            name: "2022년 11월 행사 가격",
+            price: model.price,
+            store: model.store,
+            saleType: model.saleType
+          )
+        )
+        self?.previousHistory.append(
+          ProductModel(
+            imageLink: model.imageLink,
+            name: "2022년 10월 행사 가격",
+            price: model.price,
+            store: model.store,
+            saleType: model.saleType
+          )
+        )
+        // -------------------
+        
+        self?.collectionView.reloadData()
         self?.collectionView.backgroundColor = model.store.bgColor
       })
       .disposed(by: disposeBag)
@@ -157,16 +192,21 @@ final class ProductViewController: BaseViewController, Viewable {
 extension ProductViewController: UICollectionViewDataSource {
 
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return 10
+    return self.previousHistory.count
   }
 
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
     guard let cell = collectionView.dequeueReusableCell(
       withReuseIdentifier: GoodsCell.id,
       for: indexPath
     ) as? GoodsCell else {
       fatalError("GoodsCell을 생성할 수 없습니다.")
     }
+    
+    cell.updateCell(self.previousHistory[indexPath.row], showTitleLogoView: false)
     return cell
   }
 

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -206,7 +206,7 @@ extension ProductViewController: UICollectionViewDataSource {
       fatalError("GoodsCell을 생성할 수 없습니다.")
     }
     
-    cell.updateCell(self.previousHistory[indexPath.row], showTitleLogoView: false)
+    cell.updateCell(self.previousHistory[indexPath.row], isShowTitleLogoView: false)
     return cell
   }
 

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -88,7 +88,8 @@ final class ProductViewController: BaseViewController, Viewable {
     super.setupConstraints()
 
     navigationHeaderBarView.snp.makeConstraints { make in
-      make.top.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+      make.top.equalTo(view.safeAreaLayoutGuide)
+      make.leading.trailing.equalToSuperview()
       make.height.equalTo(60)
     }
 
@@ -111,8 +112,13 @@ final class ProductViewController: BaseViewController, Viewable {
 
     collectionView.snp.makeConstraints { make in
       make.top.equalTo(navigationHeaderBarView.snp.bottom)
-      make.horizontalEdges.bottom.equalToSuperview()
+      make.leading.trailing.bottom.equalToSuperview()
     }
+  }
+  
+  override func setupStyles() {
+    super.setupStyles()
+    view.backgroundColor = .white
   }
 
   func bind(viewModel: ProductViewModel) {


### PR DESCRIPTION
## Features ✨
Product 화면의 UI를 구현했습니다.
기존에 구현했던 '공유' 버튼을 제외한 버튼은 아직 구현하지 않았습니다.


## Screenshots 📸
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-22 at 22 55 01](https://user-images.githubusercontent.com/49383370/213919715-03402361-8560-4a6e-ad76-2d0651ab77df.png)



## To Reviewers
`이전 행사 내역` 데이터는 하드코딩하여 임시로 넣었습니다. (UI 구현을 위해서)
추후에 `이전 행사 내역` 데이터 부분을 구현하면 임시 데이터는 삭제할 예정입니다.
