### PR TITLE
Storage 리팩토링

### DIFF
--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		BA9EBC1D294AED8E00167970 /* ReponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EBC1C294AED8E00167970 /* ReponseModel.swift */; };
 		BA9EDA9B2918BF2B00B97C23 /* ProductModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */; };
 		BA9EDA9D2918BF9000B97C23 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9EDA9C2918BF8F00B97C23 /* Date+.swift */; };
+		BA9F765D299F4A2900D054D2 /* UserDefaultsWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9F765C299F4A2900D054D2 /* UserDefaultsWrapper.swift */; };
 		BAA0581028D36F75000CDD11 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0580F28D36F75000CDD11 /* BaseViewController.swift */; };
 		BAA0F53128FCF88300B632AC /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */; };
 		BAA0F53528FD353500B632AC /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0F53428FD353500B632AC /* AppCoordinator.swift */; };
@@ -160,6 +161,7 @@
 		BA9EBC1C294AED8E00167970 /* ReponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReponseModel.swift; sourceTree = "<group>"; };
 		BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductModel.swift; sourceTree = "<group>"; };
 		BA9EDA9C2918BF8F00B97C23 /* Date+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
+		BA9F765C299F4A2900D054D2 /* UserDefaultsWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsWrapper.swift; sourceTree = "<group>"; };
 		BAA0580F28D36F75000CDD11 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		BAA0F53028FCF88300B632AC /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
 		BAA0F53428FD353500B632AC /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -342,9 +344,10 @@
 			children = (
 				BA27023428CF5F0D0039D9EA /* Assets */,
 				BA27023528CF5F180039D9EA /* Base */,
+				9CCFA4FB28F457E100963A95 /* Constants */,
 				A5F8288828DEC09B00C5D6A2 /* Extensions */,
 				A5932EA128E044BF00457AD3 /* Lottie */,
-				9CCFA4FB28F457E100963A95 /* Constants */,
+				BA9F765B299F4A1000D054D2 /* Manager */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -428,6 +431,14 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		BA9F765B299F4A1000D054D2 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				BA9F765C299F4A2900D054D2 /* UserDefaultsWrapper.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 		BAA21ACC29155A0F00056DB6 /* Network */ = {
@@ -694,6 +705,7 @@
 				BAD70BD8291A58CB00C39863 /* SortType.swift in Sources */,
 				E54D9C4628F1A19B00D028B2 /* BookmarkViewReactor.swift in Sources */,
 				9CDBFCD1296C331C00357474 /* SettingConfig.swift in Sources */,
+				BA9F765D299F4A2900D054D2 /* UserDefaultsWrapper.swift in Sources */,
 				E54D9C4828F1A1A300D028B2 /* BookmarkVC.swift in Sources */,
 				E55BEBE128D6A82400804FCB /* SearchBar.swift in Sources */,
 				E5467E4A28D45DF40031B785 /* TopCurveView.swift in Sources */,

--- a/PPAK_CVS/Configuration/Manager/UserDefaultsWrapper.swift
+++ b/PPAK_CVS/Configuration/Manager/UserDefaultsWrapper.swift
@@ -6,3 +6,33 @@
 //
 
 import Foundation
+
+@propertyWrapper
+struct UserDefaultsWrapper<T: Codable> {
+
+  private let key: String
+  private let defaultValue: T
+
+  init(key: String, defaultValue: T) {
+    self.key = key
+    self.defaultValue = defaultValue
+  }
+
+  var wrappedValue: T {
+    get {
+      guard let data = UserDefaults.standard.object(forKey: self.key) as? Data,
+            let decodedData = try? JSONDecoder().decode(T.self, from: data) else {
+        return defaultValue
+      }
+      return decodedData
+    }
+    set {
+      guard let data = try? JSONEncoder().encode(newValue)
+      else {
+        UserDefaults.standard.removeObject(forKey: key)
+        return
+      }
+      UserDefaults.standard.set(data, forKey: key)
+    }
+  }
+}

--- a/PPAK_CVS/Configuration/Manager/UserDefaultsWrapper.swift
+++ b/PPAK_CVS/Configuration/Manager/UserDefaultsWrapper.swift
@@ -1,0 +1,8 @@
+//
+//  UserDefaultsWrapper.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2023/02/17.
+//
+
+import Foundation

--- a/PPAK_CVS/Sources/AppCoordinator.swift
+++ b/PPAK_CVS/Sources/AppCoordinator.swift
@@ -14,7 +14,7 @@ final class AppCoordinator: BaseCoordinator {
 
     // == first launch check ==
     let coordinator: Coordinator
-    if FTUXStorage().isAlreadyCome() {
+    if FTUXStorage().wasLaunchedBefore {
       coordinator = HomeCoordinator(navigationController: self.navigationController)
     } else {
       coordinator = OnboardingCoordinator(navigationController: self.navigationController)

--- a/PPAK_CVS/Sources/Storage/CVSStorage.swift
+++ b/PPAK_CVS/Sources/Storage/CVSStorage.swift
@@ -13,55 +13,21 @@ final class CVSStorage {
 
   static let shared = CVSStorage()
 
-  private let key = "CVS"
-  private let favoriteCVSKey = "favoriteCVS"
-  private let userDefaults = UserDefaults.standard
   private init() {}
 
-  lazy var didChangeCVS = PublishSubject<CVSType>()
+  let didChangeCVS = PublishSubject<CVSType>()
 
-  lazy var cvs: CVSType = load() {
-    didSet {
-      if let encoded = try? JSONEncoder().encode(cvs) {
-        userDefaults.set(encoded, forKey: key)
-      }
-    }
-  }
-
-  private func load() -> CVSType {
-    guard let data = userDefaults.object(forKey: key) as? Data else { return .all }
-    if let cvs = try? JSONDecoder().decode(CVSType.self, from: data) {
-      return cvs
-    } else {
-      return .all
-    }
-  }
+  @UserDefaultsWrapper<CVSType>(key: "CVS", defaultValue: .all)
+  private(set) var cvs
 
   func save(_ cvs: CVSType) {
     self.cvs = cvs
   }
 
-  // --- 자주 가는 편의점 ---
+  // MARK: - 자주 가는 편의점
 
-  lazy var favoriteCVS: CVSType = self.loadFavoriteCVS() {
-    didSet {
-      if let encoded = try? JSONEncoder().encode(self.favoriteCVS) {
-        self.userDefaults.set(encoded, forKey: self.favoriteCVSKey)
-      }
-    }
-  }
-
-  private func loadFavoriteCVS() -> CVSType {
-    guard let data = userDefaults.object(forKey: self.favoriteCVSKey) as? Data else {
-      return .all
-    }
-
-    if let cvs = try? JSONDecoder().decode(CVSType.self, from: data) {
-      return cvs
-    } else {
-      return .all
-    }
-  }
+  @UserDefaultsWrapper<CVSType>(key: "favoriteCVS", defaultValue: .all)
+  private(set) var favoriteCVS
 
   func saveToFavorite(_ cvs: CVSType) {
     self.favoriteCVS = cvs

--- a/PPAK_CVS/Sources/Storage/FTUXStorage.swift
+++ b/PPAK_CVS/Sources/Storage/FTUXStorage.swift
@@ -12,11 +12,7 @@ final class FTUXStorage {
   @UserDefaultsWrapper<Bool>(key: "localStorage_is_already_come", defaultValue: false)
   private(set) var wasLaunchedBefore // 이전에 실행했던 적이 있는지 확인
 
-  public func isAlreadyCome() -> Bool {
-    wasLaunchedBefore
-  }
-
-  public func saveFTUXStatus() {
+  func saveFTUXStatus() {
     wasLaunchedBefore = true
   }
 }

--- a/PPAK_CVS/Sources/Storage/FTUXStorage.swift
+++ b/PPAK_CVS/Sources/Storage/FTUXStorage.swift
@@ -9,14 +9,14 @@ import Foundation
 
 final class FTUXStorage {
 
-  private let key = "localStorage_is_already_come"
-  private let userDefaults = UserDefaults.standard
+  @UserDefaultsWrapper<Bool>(key: "localStorage_is_already_come", defaultValue: false)
+  private(set) var wasLaunchedBefore // 이전에 실행했던 적이 있는지 확인
 
   public func isAlreadyCome() -> Bool {
-    self.userDefaults.bool(forKey: key)
+    wasLaunchedBefore
   }
 
   public func saveFTUXStatus() {
-    self.userDefaults.set(true, forKey: key)
+    wasLaunchedBefore = true
   }
 }

--- a/PPAK_CVS/Sources/Storage/ProductStorage.swift
+++ b/PPAK_CVS/Sources/Storage/ProductStorage.swift
@@ -11,26 +11,10 @@ final class ProductStorage {
 
   static let shared = ProductStorage()
 
-  private let key = "Storage"
-  private let userDefaults = UserDefaults.standard
   private init() {}
 
-  private(set) lazy var products: [ProductModel] = load() {
-    didSet {
-      if let encoded = try? JSONEncoder().encode(products) {
-        userDefaults.set(encoded, forKey: key)
-      }
-    }
-  }
-
-  private func load() -> [ProductModel] {
-    guard let data = userDefaults.object(forKey: key) as? Data else { return [] }
-    if let products = try? JSONDecoder().decode([ProductModel].self, from: data) {
-      return products
-    } else {
-      return []
-    }
-  }
+  @UserDefaultsWrapper<[ProductModel]>(key: "Storage", defaultValue: [])
+  private(set) var products
 
   func add(_ from: ProductModel) {
     products.insert(from, at: 0)


### PR DESCRIPTION
## Features ✨

UserDefaultsWrapper를 구현하여 Storage의 반복적인 코드(load 함수, 반복적인 didSet)를 제거했습니다.

## Screenshots 📸

|CVSStorage|
|:-:|
|![image](https://user-images.githubusercontent.com/57972338/219563916-7de6eccb-3874-4180-8615-366ded147954.png)|
|ProductStorage|
|![image](https://user-images.githubusercontent.com/57972338/219564097-6b8cc0c2-1931-46fa-970d-dc36975e799f.png)|
|FTUXStorage|
|![image](https://user-images.githubusercontent.com/57972338/219564167-6d479b1f-87af-451a-bb01-6f9d0d5f065d.png)|



## To Reviewers

FTUXStorage는 변수가 존재하지 않아 제가 임의로 설정했습니다. 그러면서 `isAlreadyCome()`메서드와 `wasLaunchedBefore`의 역할이 중복되어버렸는데, 하나로 통합하는 게 좋을 것 같아요.
