### PR TITLE
[API] 이전 행사 내역 추가

### DIFF
--- a/PPAK_CVS/Sources/Models/ProductModel.swift
+++ b/PPAK_CVS/Sources/Models/ProductModel.swift
@@ -12,6 +12,8 @@ struct ProductModel: Codable, Equatable {
   let imageLink: String?
   /// 물품명
   let name: String
+  /// 할인행사 날짜
+  let dateString: String
   /// 가격
   let price: Int
   /// 편의점 가게
@@ -23,6 +25,7 @@ struct ProductModel: Codable, Equatable {
     case name
     case price
     case store
+    case dateString = "date"
     case imageLink = "img"
     case saleType = "tag"
   }

--- a/PPAK_CVS/Sources/Network/ProductTarget.swift
+++ b/PPAK_CVS/Sources/Network/ProductTarget.swift
@@ -11,6 +11,7 @@ import Alamofire
 
 enum ProductTarget {
   case search(RequestTypeModel)
+  case history(RequestTypeModel)
 }
 
 extension ProductTarget: TargetType {
@@ -24,12 +25,16 @@ extension ProductTarget: TargetType {
     switch self {
     case .search:
       return "\(uri)/search"
+    case .history:
+      return "\(uri)/history"
     }
   }
 
   var parameters: Parameters {
     switch self {
     case .search(let model):
+      return model.parameters
+    case .history(let model):
       return model.parameters
     }
   }

--- a/PPAK_CVS/Sources/Network/PyeonHaengAPI.swift
+++ b/PPAK_CVS/Sources/Network/PyeonHaengAPI.swift
@@ -30,4 +30,21 @@ final class PyeonHaengAPI {
     }
     .asObservable()
   }
+
+  func history(request: RequestTypeModel) -> Observable<ResponseModel> {
+    return Single.create { observer in
+      AF.request(ProductTarget.history(request))
+        .responseDecodable(of: ResponseModel.self) { response in
+          switch response.result {
+          case .success(let model):
+            observer(.success(model))
+          case .failure(let error):
+            observer(.failure(error))
+          }
+        }
+
+      return Disposables.create()
+    }
+    .asObservable()
+  }
 }

--- a/PPAK_CVS/Sources/Scenes/Home/HomeViewReactor.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeViewReactor.swift
@@ -44,7 +44,7 @@ final class HomeViewReactor: Reactor {
     var isVisibleFilterDropdown: Bool = false
     var showsKeyboard: Bool = false
     var showsBookmarkVC: (Bool, CVSType) = (false, .all)
-    var showsProductVC: (Bool, ProductModel) = (false, .init(imageLink: nil, name: "", price: 0, store: .all, saleType: .all))
+    var showsProductVC: (Bool, ProductModel) = (false, .init(imageLink: nil, name: "", dateString: "", price: 0, store: .all, saleType: .all))
     var showsSettingVC: Bool = false
     var currentSortType: SortType = .none
     var currentEventType: EventType = .all

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCoordinator.swift
@@ -24,7 +24,7 @@ final class ProductCoordinator: BaseCoordinator {
   }
 
   private override init(navigationController: UINavigationController) {
-    self.model = ProductModel(imageLink: "", name: "", price: 0, store: .all, saleType: .all)
+    self.model = ProductModel(imageLink: "", name: "", dateString: "", price: 0, store: .all, saleType: .all)
     super.init(navigationController: navigationController)
   }
 

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -164,6 +164,7 @@ final class ProductViewController: BaseViewController, View {
           ProductModel(
             imageLink: model.imageLink,
             name: "2022년 12월 행사 가격",
+            dateString: "",
             price: model.price,
             store: model.store,
             saleType: model.saleType
@@ -173,6 +174,7 @@ final class ProductViewController: BaseViewController, View {
           ProductModel(
             imageLink: model.imageLink,
             name: "2022년 11월 행사 가격",
+            dateString: "",
             price: model.price,
             store: model.store,
             saleType: model.saleType
@@ -182,6 +184,7 @@ final class ProductViewController: BaseViewController, View {
           ProductModel(
             imageLink: model.imageLink,
             name: "2022년 10월 행사 가격",
+            dateString: "",
             price: model.price,
             store: model.store,
             saleType: model.saleType

--- a/PPAK_CVS/Sources/Scenes/Product/ProductViewReactor.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductViewReactor.swift
@@ -29,7 +29,7 @@ final class ProductViewReactor: Reactor {
   }
 
   struct State {
-    var model = ProductModel(imageLink: "", name: "", price: 0, store: .all, saleType: .all)
+    var model = ProductModel(imageLink: "", name: "", dateString: "", price: 0, store: .all, saleType: .all)
     var isPopProductVC: Bool = false
     var isBookmark: Bool = false
     var isShareButtonTapped: Bool = false


### PR DESCRIPTION
## Features ✨

- 특정 제품의 이전 행사 내역 리스트를 가지고오는 API 구현

```swift
let model = RequestTypeModel(cvs: .cu, event: .all, sort: .none, name: "메디안)치석케어치약")
PyeonHaengAPI.shared.history(request: model)
  .subscribe(with: self) { owner, model in
    print(model)
  }
  .disposed(by: disposeBag)
```


## Screenshots 📸

![image](https://user-images.githubusercontent.com/57972338/219604878-6e59e5a2-e064-409a-a9d4-08835fe8da2c.png)
