### PR TITLE
[Product] 이전 행사 내역 구현

### DIFF
--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		A5F8288E28DED76700C5D6A2 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F8288D28DED76700C5D6A2 /* UILabel+.swift */; };
 		BA1CCAC228FAFE500002FD8C /* WeakMapTable in Frameworks */ = {isa = PBXBuildFile; productRef = BA1CCAC128FAFE500002FD8C /* WeakMapTable */; };
 		BA1FC11C29A4D2D500AB3F91 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BA1FC11B29A4D2D500AB3F91 /* GoogleService-Info.plist */; };
+		BA1FC11E29A4DECA00AB3F91 /* RequestHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1FC11D29A4DECA00AB3F91 /* RequestHistoryModel.swift */; };
 		BA27023128CF5DCD0039D9EA /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA27023028CF5DCD0039D9EA /* Coordinator.swift */; };
 		BA27023928CF60570039D9EA /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = BA27023828CF60570039D9EA /* SnapKit */; };
 		BA27023C28CF606A0039D9EA /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = BA27023B28CF606A0039D9EA /* Then */; };
@@ -162,6 +163,7 @@
 		A5F8288B28DECEE700C5D6A2 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		A5F8288D28DED76700C5D6A2 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		BA1FC11B29A4D2D500AB3F91 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		BA1FC11D29A4DECA00AB3F91 /* RequestHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestHistoryModel.swift; sourceTree = "<group>"; };
 		BA27023028CF5DCD0039D9EA /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BA27024828CF618E0039D9EA /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		BA343AB02963139900DE8016 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 				BA9EDA9A2918BF2B00B97C23 /* ProductModel.swift */,
 				BA9EBC1C294AED8E00167970 /* ReponseModel.swift */,
 				BAD70BD9291A594F00C39863 /* RequestTypeModel.swift */,
+				BA1FC11D29A4DECA00AB3F91 /* RequestHistoryModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -724,6 +727,7 @@
 				BA8CFD7D28E1E4AB00ADC4A8 /* UIColor+.swift in Sources */,
 				E5103251290B4A0300D2F007 /* UIView+.swift in Sources */,
 				A52F114229A0A07D009FFE02 /* NoticeViewReactor.swift in Sources */,
+				BA1FC11E29A4DECA00AB3F91 /* RequestHistoryModel.swift in Sources */,
 				A5F8288C28DECEE700C5D6A2 /* Strings.swift in Sources */,
 				9C798F8A28EAE9DA00FE250C /* TitleLogoView.swift in Sources */,
 				9CA7150E293CE26300AEE436 /* NSAttributedString+.swift in Sources */,

--- a/PPAK_CVS.xcodeproj/project.pbxproj
+++ b/PPAK_CVS.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		9CA7150E293CE26300AEE436 /* NSAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA7150D293CE26300AEE436 /* NSAttributedString+.swift */; };
 		9CCFA4FE28F4585E00963A95 /* EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCFA4FD28F4585E00963A95 /* EventType.swift */; };
 		9CDBFCD1296C331C00357474 /* SettingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDBFCD0296C331C00357474 /* SettingConfig.swift */; };
-		A52F112D29A098FA009FFE02 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A52F112C29A098F9009FFE02 /* GoogleService-Info.plist */; };
 		A52F113329A09D6E009FFE02 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = A52F113229A09D6E009FFE02 /* FirebaseAnalytics */; };
 		A52F113529A09D6E009FFE02 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = A52F113429A09D6E009FFE02 /* FirebaseCrashlytics */; };
 		A52F113729A09D6E009FFE02 /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = A52F113629A09D6E009FFE02 /* FirebaseInAppMessaging-Beta */; };
@@ -59,6 +58,7 @@
 		A5F8288C28DECEE700C5D6A2 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F8288B28DECEE700C5D6A2 /* Strings.swift */; };
 		A5F8288E28DED76700C5D6A2 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F8288D28DED76700C5D6A2 /* UILabel+.swift */; };
 		BA1CCAC228FAFE500002FD8C /* WeakMapTable in Frameworks */ = {isa = PBXBuildFile; productRef = BA1CCAC128FAFE500002FD8C /* WeakMapTable */; };
+		BA1FC11C29A4D2D500AB3F91 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BA1FC11B29A4D2D500AB3F91 /* GoogleService-Info.plist */; };
 		BA27023128CF5DCD0039D9EA /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA27023028CF5DCD0039D9EA /* Coordinator.swift */; };
 		BA27023928CF60570039D9EA /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = BA27023828CF60570039D9EA /* SnapKit */; };
 		BA27023C28CF606A0039D9EA /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = BA27023B28CF606A0039D9EA /* Then */; };
@@ -128,7 +128,6 @@
 		9CA7150D293CE26300AEE436 /* NSAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+.swift"; sourceTree = "<group>"; };
 		9CCFA4FD28F4585E00963A95 /* EventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventType.swift; sourceTree = "<group>"; };
 		9CDBFCD0296C331C00357474 /* SettingConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingConfig.swift; sourceTree = "<group>"; };
-		A52F112C29A098F9009FFE02 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Documents/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A52F113C29A09FF4009FFE02 /* NoticeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeVC.swift; sourceTree = "<group>"; };
 		A52F113F29A0A02F009FFE02 /* NoticeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeCoordinator.swift; sourceTree = "<group>"; };
 		A52F114129A0A07D009FFE02 /* NoticeViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewReactor.swift; sourceTree = "<group>"; };
@@ -162,6 +161,7 @@
 		A5F8288928DEC0CF00C5D6A2 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		A5F8288B28DECEE700C5D6A2 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		A5F8288D28DED76700C5D6A2 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		BA1FC11B29A4D2D500AB3F91 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BA27023028CF5DCD0039D9EA /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BA27024828CF618E0039D9EA /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		BA343AB02963139900DE8016 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
@@ -506,7 +506,7 @@
 				BA27023228CF5EF30039D9EA /* Configuration */,
 				BA27023328CF5EFF0039D9EA /* Sources */,
 				E505D9F828CF5B4B00EEFC65 /* Info.plist */,
-				A52F112C29A098F9009FFE02 /* GoogleService-Info.plist */,
+				BA1FC11B29A4D2D500AB3F91 /* GoogleService-Info.plist */,
 				A52F114329A0A2F1009FFE02 /* NoticeInfo.plist */,
 				E53D1A3B2987EBE20074308B /* .swiftlint.yml */,
 			);
@@ -652,8 +652,8 @@
 				A5932EA328E044CB00457AD3 /* onboarding1.json in Resources */,
 				A54949D3296F052F00844828 /* noBookmark.json in Resources */,
 				A5B69C3A2960095100052D2B /* Pretendard-Medium.otf in Resources */,
+				BA1FC11C29A4D2D500AB3F91 /* GoogleService-Info.plist in Resources */,
 				A5932EA528E045EF00457AD3 /* onboarding3.json in Resources */,
-				A52F112D29A098FA009FFE02 /* GoogleService-Info.plist in Resources */,
 				A5D5A6F12985629100AD4F6E /* EF_jejudoldam.otf in Resources */,
 				A5932EA728E0472B00457AD3 /* onboarding2.json in Resources */,
 				A5B69C392960095100052D2B /* Pretendard-ExtraBold.otf in Resources */,

--- a/PPAK_CVS/Sources/Models/ProductModel.swift
+++ b/PPAK_CVS/Sources/Models/ProductModel.swift
@@ -13,7 +13,7 @@ struct ProductModel: Codable, Equatable {
   /// 이미지 주소
   let imageLink: String?
   /// 물품명
-  let name: String
+  var name: String
   /// 할인행사 날짜
   let dateString: String
   /// 가격

--- a/PPAK_CVS/Sources/Models/ProductModel.swift
+++ b/PPAK_CVS/Sources/Models/ProductModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import Then
+
 struct ProductModel: Codable, Equatable {
   /// 이미지 주소
   let imageLink: String?
@@ -30,3 +32,5 @@ struct ProductModel: Codable, Equatable {
     case saleType = "tag"
   }
 }
+
+extension ProductModel: Then { }

--- a/PPAK_CVS/Sources/Models/RequestHistoryModel.swift
+++ b/PPAK_CVS/Sources/Models/RequestHistoryModel.swift
@@ -1,0 +1,13 @@
+//
+//  RequestHistoryModel.swift
+//  PPAK_CVS
+//
+//  Created by 홍승현 on 2023/02/21.
+//
+
+import Foundation
+
+struct RequestHistoryModel: Codable {
+  let cvs: CVSType
+  let name: String
+}

--- a/PPAK_CVS/Sources/Network/ProductTarget.swift
+++ b/PPAK_CVS/Sources/Network/ProductTarget.swift
@@ -11,7 +11,7 @@ import Alamofire
 
 enum ProductTarget {
   case search(RequestTypeModel)
-  case history(RequestTypeModel)
+  case history(RequestHistoryModel)
 }
 
 extension ProductTarget: TargetType {

--- a/PPAK_CVS/Sources/Network/PyeonHaengAPI.swift
+++ b/PPAK_CVS/Sources/Network/PyeonHaengAPI.swift
@@ -31,7 +31,7 @@ final class PyeonHaengAPI {
     .asObservable()
   }
 
-  func history(request: RequestTypeModel) -> Observable<ResponseModel> {
+  func history(request: RequestHistoryModel) -> Observable<ResponseModel> {
     return Single.create { observer in
       AF.request(ProductTarget.history(request))
         .responseDecodable(of: ResponseModel.self) { response in

--- a/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
@@ -13,10 +13,14 @@ import RxCocoa
 import SnapKit
 import Then
 
+protocol ProductDataStore {
+  var shareImage: UIImage { get }
+}
+
 final class ProductCollectionHeaderView: UICollectionReusableView {
   static let id = "ProductCollectionHeaderView"
 
-  var disposeBag = DisposeBag()
+  private let disposeBag = DisposeBag()
 
   private let productImageView = UIImageView().then {
     $0.image = UIImage(named: "ic_noImage_large")
@@ -145,8 +149,12 @@ extension ProductCollectionHeaderView {
 
     curveView.backgroundColor = model.store.bgColor
   }
+}
 
-  func getShareImage() -> UIImage {
+// MARK: - ProductDataStore
+
+extension ProductCollectionHeaderView: ProductDataStore {
+  var shareImage: UIImage {
     let renderer = UIGraphicsImageRenderer(bounds: self.wholeStackView.bounds)
     return renderer.image { rendererContext in
       self.wholeStackView.layer.render(in: rendererContext.cgContext)

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -15,9 +15,6 @@ import Then
 
 final class ProductViewController: BaseViewController, View {
 
-  // test data (will delete)
-  private var previousHistory: [ProductModel] = []
-
   private let navigationHeaderBarView = UIView().then {
     $0.backgroundColor = .white
   }
@@ -154,40 +151,7 @@ final class ProductViewController: BaseViewController, View {
         guard let self = self else { return }
 
         headerView.configureUI(with: model)
-
-        // --- test data(will delete) ---
-        self.previousHistory.append(
-          ProductModel(
-            imageLink: model.imageLink,
-            name: "2022년 12월 행사 가격",
-            dateString: "",
-            price: model.price,
-            store: model.store,
-            saleType: model.saleType
-          )
-        )
-        self.previousHistory.append(
-          ProductModel(
-            imageLink: model.imageLink,
-            name: "2022년 11월 행사 가격",
-            dateString: "",
-            price: model.price,
-            store: model.store,
-            saleType: model.saleType
-          )
-        )
-        self.previousHistory.append(
-          ProductModel(
-            imageLink: model.imageLink,
-            name: "2022년 10월 행사 가격",
-            dateString: "",
-            price: model.price,
-            store: model.store,
-            saleType: model.saleType
-          )
-        )
-        // -------------------
-
+        
         self.collectionView.reloadData()
         self.collectionView.backgroundColor = model.store.bgColor
       })
@@ -220,7 +184,7 @@ final class ProductViewController: BaseViewController, View {
 extension ProductViewController: UICollectionViewDataSource {
 
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return self.previousHistory.count
+    return 0
   }
 
   func collectionView(
@@ -234,7 +198,6 @@ extension ProductViewController: UICollectionViewDataSource {
       fatalError("GoodsCell을 생성할 수 없습니다.")
     }
 
-    cell.updateCell(self.previousHistory[indexPath.row], isShowTitleLogoView: false)
     return cell
   }
 

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -194,7 +194,16 @@ extension ProductViewController: UICollectionViewDataSource {
     }
 
     guard let reactor else { return cell }
-    cell.updateCell(reactor.currentState.historyModels[indexPath.row], isShowTitleLogoView: false)
+    let product = reactor.currentState.historyModels[indexPath.row]
+    let transformedProduct = ProductModel(
+      imageLink: product.imageLink,
+      name: product.dateString.components(separatedBy: ":").joined(separator: "년 ") + "월 행사 가격",
+      dateString: product.dateString,
+      price: product.price,
+      store: product.store,
+      saleType: product.saleType
+    )
+    cell.updateCell(transformedProduct, isShowTitleLogoView: false)
 
     return cell
   }

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -137,9 +137,7 @@ final class ProductViewController: BaseViewController, View {
 
     reactor.state
       .map { $0.model.store.bgColor }
-      .subscribe(with: self) { owner, backgroundColor in
-        owner.collectionView.backgroundColor = backgroundColor
-      }
+      .bind(to: self.collectionView.rx.backgroundColor)
       .disposed(by: disposeBag)
 
     // 이미지 공유하기

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -192,16 +192,10 @@ extension ProductViewController: UICollectionViewDataSource {
     }
 
     guard let reactor else { return cell }
-    let product = reactor.currentState.historyModels[indexPath.row]
-    let transformedProduct = ProductModel(
-      imageLink: product.imageLink,
-      name: product.dateString.components(separatedBy: ":").joined(separator: "년 ") + "월 행사 가격",
-      dateString: product.dateString,
-      price: product.price,
-      store: product.store,
-      saleType: product.saleType
-    )
-    cell.updateCell(transformedProduct, isShowTitleLogoView: false)
+    let product = reactor.currentState.historyModels[indexPath.row].with {
+      $0.name = $0.dateString.components(separatedBy: ":").joined(separator: "년 ") + "월 행사 가격"
+    }
+    cell.updateCell(product, isShowTitleLogoView: false)
 
     return cell
   }

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -41,13 +41,8 @@ final class ProductViewController: BaseViewController, View {
 
   private lazy var collectionView = UICollectionView(
     frame: .zero,
-    collectionViewLayout: .init()
+    collectionViewLayout: UICollectionViewFlowLayout()
   ).then {
-    $0.collectionViewLayout = UICollectionViewFlowLayout().then { layout in
-      layout.headerReferenceSize = CGSize(width: view.bounds.width, height: 404)
-      layout.itemSize = CGSize(width: self.view.bounds.width, height: 125)
-      layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0)
-    }
     $0.bounces = false
     $0.register(GoodsCell.self, forCellWithReuseIdentifier: GoodsCell.id)
     $0.register(
@@ -55,6 +50,7 @@ final class ProductViewController: BaseViewController, View {
       forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
       withReuseIdentifier: ProductCollectionHeaderView.id
     )
+    $0.delegate = self
     $0.dataSource = self
     $0.backgroundColor = .systemPurple
   }
@@ -262,5 +258,30 @@ extension ProductViewController: UICollectionViewDataSource {
     }
 
     return headerView
+  }
+}
+
+extension ProductViewController: UICollectionViewDelegateFlowLayout {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
+    return CGSize(width: self.view.bounds.width, height: 125)
+  }
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    insetForSectionAt section: Int
+  ) -> UIEdgeInsets {
+    return UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    referenceSizeForHeaderInSection section: Int
+  ) -> CGSize {
+    return CGSize(width: self.view.bounds.width, height: 404)
   }
 }

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -39,7 +39,7 @@ final class ProductViewController: BaseViewController, View {
     $0.setImage(UIImage(named: "ic_share"), for: .normal)
   }
 
-  private lazy var collectionView = UICollectionView(
+  private let collectionView = UICollectionView(
     frame: .zero,
     collectionViewLayout: UICollectionViewFlowLayout()
   ).then {
@@ -50,8 +50,6 @@ final class ProductViewController: BaseViewController, View {
       forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
       withReuseIdentifier: ProductCollectionHeaderView.id
     )
-    $0.delegate = self
-    $0.dataSource = self
     $0.backgroundColor = .systemPurple
   }
 
@@ -66,6 +64,8 @@ final class ProductViewController: BaseViewController, View {
 
   override func viewDidLoad() {
     super.viewDidLoad()
+    collectionView.dataSource = self
+    collectionView.delegate = self
   }
 
   override func setupLayouts() {

--- a/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductVC.swift
@@ -157,6 +157,15 @@ final class ProductViewController: BaseViewController, View {
       .map { $0.isBookmark }
       .bind(to: self.bookmarkButton.rx.isSelected)
       .disposed(by: disposeBag)
+
+    // 이전 행사 내역 업데이트
+    reactor.state
+      .map { $0.historyModels }
+      .distinctUntilChanged()
+      .subscribe(with: self) { owner, _ in
+        owner.collectionView.reloadData()
+      }
+      .disposed(by: disposeBag)
   }
 
   /// 공유버튼을 눌렀을 때 실행되는 메서드입니다.
@@ -169,7 +178,8 @@ final class ProductViewController: BaseViewController, View {
 extension ProductViewController: UICollectionViewDataSource {
 
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return 0
+    guard let reactor else { return 0 }
+    return reactor.currentState.historyModels.count
   }
 
   func collectionView(
@@ -182,6 +192,9 @@ extension ProductViewController: UICollectionViewDataSource {
     ) as? GoodsCell else {
       fatalError("GoodsCell을 생성할 수 없습니다.")
     }
+
+    guard let reactor else { return cell }
+    cell.updateCell(reactor.currentState.historyModels[indexPath.row], isShowTitleLogoView: false)
 
     return cell
   }

--- a/PPAK_CVS/Sources/Scenes/Product/ProductViewReactor.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductViewReactor.swift
@@ -48,7 +48,7 @@ final class ProductViewReactor: Reactor {
         .just(.changeBookmarkState(ProductStorage.shared.contains(model))),
         // API 요청 후 Mutation으로 매핑
         PyeonHaengAPI.shared.history(request: RequestHistoryModel(cvs: model.store, name: model.name))
-          .flatMap { Observable<Mutation>.just(.updateHistoryProduct($0.products)) }
+          .flatMap { Observable<Mutation>.just(.updateHistoryProduct($0.products.reversed())) }
       ])
 
     case .back:

--- a/PPAK_CVS/Sources/Scenes/Product/ProductViewReactor.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductViewReactor.swift
@@ -22,6 +22,7 @@ final class ProductViewReactor: Reactor {
 
   enum Mutation {
     case updateProduct(ProductModel)
+    case updateHistoryProduct([ProductModel])
     case goToHomeVC
     case changeBookmarkState(Bool)
     case showShareWindow(Bool)
@@ -30,6 +31,7 @@ final class ProductViewReactor: Reactor {
 
   struct State {
     var model = ProductModel(imageLink: "", name: "", dateString: "", price: 0, store: .all, saleType: .all)
+    var historyModels: [ProductModel] = []
     var isPopProductVC: Bool = false
     var isBookmark: Bool = false
     var isShareButtonTapped: Bool = false
@@ -43,7 +45,10 @@ final class ProductViewReactor: Reactor {
     case .updateProduct(let model):
       return .concat([
         .just(.updateProduct(model)),
-        .just(.changeBookmarkState(ProductStorage.shared.contains(model)))
+        .just(.changeBookmarkState(ProductStorage.shared.contains(model))),
+        // API 요청 후 Mutation으로 매핑
+        PyeonHaengAPI.shared.history(request: RequestHistoryModel(cvs: model.store, name: model.name))
+          .flatMap { Observable<Mutation>.just(.updateHistoryProduct($0.products)) }
       ])
 
     case .back:
@@ -71,6 +76,9 @@ final class ProductViewReactor: Reactor {
     switch mutation {
     case .updateProduct(let model):
       newState.model = model
+
+    case .updateHistoryProduct(let models):
+      newState.historyModels = models
 
     case .goToHomeVC:
       newState.isPopProductVC = true


### PR DESCRIPTION
## Features ✨

- 이전행사 내역에 관한 네트워크 구현 (history model)
   - 이전PR 때 구현해두었으나, 요청모델을 분리하지 않았어서 이번 PR 때 수정했습니다.
- 이전행사 내역을 가지고 올 수 있도록 Reactor에서 Flow 구현
   - ProductModel을 Coordinator로부터 받았을 때 API를 실행시켜 이전 행사내역도 바로 받아올 수 있도록 처리했습니다.
      ```swift
        case .updateProduct(let model):
          return .concat([
            .just(.updateProduct(model)),
            .just(.changeBookmarkState(ProductStorage.shared.contains(model))),
            // API 요청 후 Mutation으로 매핑
            PyeonHaengAPI.shared.history(request: RequestHistoryModel(cvs: model.store, name: model.name))
              .flatMap { Observable<Mutation>.just(.updateHistoryProduct($0.products.reversed())) }
          ])
      ```

## Screenshots 📸

|실행영상|
|:-:|
|<img src="https://user-images.githubusercontent.com/57972338/220402798-01bf62e3-f17e-4218-8f51-f74bb3773035.gif" width="50%"/>|



## To Reviewers

- Retain-Cycle에 걸리는 코드들이 있는데, 이는 다음에 리팩토링하면서 PR 올리도록 하겠습니다.
- 이전 행사 내역이 없는 경우 빈 공간만을 보여주게 되는데, 없을 때 사용자에게 알릴 UI 디자인이 필요할 것 같아요.
