### PR TITLE
[ADD] 공유 이미지 패딩 처리

### DIFF
--- a/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
+++ b/PPAK_CVS/Sources/Scenes/Product/ProductCollectionHeaderView.swift
@@ -155,7 +155,15 @@ extension ProductCollectionHeaderView {
 
 extension ProductCollectionHeaderView: ProductDataStore {
   var shareImage: UIImage {
-    let renderer = UIGraphicsImageRenderer(bounds: self.wholeStackView.bounds)
+    let horizontalPadding: Double = 20
+    let verticalPadding: Double = 40
+    var transformedBounds = self.wholeStackView.bounds.with {
+      $0.origin.x = -horizontalPadding
+      $0.origin.y = -verticalPadding
+      $0.size.width = $0.width + horizontalPadding * 2
+      $0.size.height = $0.height + verticalPadding * 2
+    }
+    let renderer = UIGraphicsImageRenderer(bounds: transformedBounds)
     return renderer.image { rendererContext in
       self.wholeStackView.layer.render(in: rendererContext.cgContext)
     }


### PR DESCRIPTION
## Features ✨

- 양옆 각 20씩, 위아래 각 40씩 패딩 처리하였습니다(`shareImage` 타입 프로퍼티 내부에 패딩값을 처리함).

## Screenshots 📸

|전|후|
|:-:|:-:|
|![IMG_1784](https://user-images.githubusercontent.com/57972338/221367902-c1e345b8-3317-4a44-894d-3d19e7bb821b.JPG)|![IMG_1783](https://user-images.githubusercontent.com/57972338/221367900-a0a19523-4ea4-4607-911e-e832227cf7f9.JPG)|
