### PR TITLE
[BUG] NavigationController PopGesture 버그 수정

### DIFF
--- a/PPAK_CVS/Configuration/Base/BaseViewController.swift
+++ b/PPAK_CVS/Configuration/Base/BaseViewController.swift
@@ -18,6 +18,7 @@ class BaseViewController: UIViewController {
   }
 
   override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
     navigationController?.interactivePopGestureRecognizer?.delegate = self
   }
 

--- a/PPAK_CVS/Configuration/Base/BaseViewController.swift
+++ b/PPAK_CVS/Configuration/Base/BaseViewController.swift
@@ -15,6 +15,9 @@ class BaseViewController: UIViewController {
     setupLayouts()
     setupConstraints()
     setupStyles()
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
     navigationController?.interactivePopGestureRecognizer?.delegate = self
   }
 

--- a/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkVC.swift
+++ b/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkVC.swift
@@ -54,7 +54,12 @@ final class BookmarkViewController: BaseViewController, View {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.reactor?.action.onNext(.viewDidLoad)
+    reactor?.action.onNext(.viewDidLoad)
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    reactor?.action.onNext(.viewWillAppear)
   }
 
   // MARK: - Setup

--- a/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkViewReactor.swift
+++ b/PPAK_CVS/Sources/Scenes/Bookmark/BookmarkViewReactor.swift
@@ -5,6 +5,7 @@ final class BookmarkViewReactor: Reactor {
 
   enum Action {
     case viewDidLoad
+    case viewWillAppear
     case didTapCVSButton
     case didTapSortButton
     case didTapBackButton
@@ -59,6 +60,15 @@ final class BookmarkViewReactor: Reactor {
     switch action {
     case .viewDidLoad:
       let products = ProductStorage.shared.retrieve(cvs: currentState.currentCVS)
+      return .just(.setProducts(products))
+
+    case .viewWillAppear:
+      let products = ProductStorage.shared.retrieve(
+        cvs: currentState.currentCVS,
+        event: currentState.currentEvent,
+        sort: currentState.currentSort,
+        target: currentState.currentTarget
+        )
       return .just(.setProducts(products))
 
     case .didTapCVSButton:

--- a/PPAK_CVS/Sources/Scenes/Home/HomeViewReactor.swift
+++ b/PPAK_CVS/Sources/Scenes/Home/HomeViewReactor.swift
@@ -83,7 +83,6 @@ final class HomeViewReactor: Reactor {
           offset: nextOffset,
           name: currentState.currentTarget
         )
-        .delay(.seconds(1), scheduler: MainScheduler.instance)
       ])
 
     case .didTapBackground:


### PR DESCRIPTION
## Features ✨

1. `NavigationController`의 `BookmarkVC`의 `PopGesture`가 제대로 작동하지 않은 버그를 수정했습니다.

> 원인
```swift
// BaseViewController.swift

  override func viewDidLoad() { // ❌
    navigationController?.interactivePopGestureRecognizer?.delegate = self
  }
```

- `viewDidLoad`에 위 코드를 작성하면 다른 `VC`에서 `Pop`이 되고 되돌아오면 `delegate`가 현재 VC를 받지 못 해서 아래의 메서드가 불려지지 않습니다.

```swift
extension BaseViewController: UIGestureRecognizerDelegate {
  func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
    return navigationController?.viewControllers.count ?? 0 > 1
  }
}
```

> 해결
- viewWillAppear의 코드를 옮겨 구현했습니다.

```swift
  override func viewWillAppear(_ animated: Bool) { // 🟢
    navigationController?.interactivePopGestureRecognizer?.delegate = self
  }
```

---

2. `Pagination`을 할 때 맨 아래 `LoadingCell`을 의도적으로 `1초 delay`시키는 오퍼레이터를 삭제했습니다.

--- 

3. `Bookmark`에서 찜한 상품을 선택하고 찜을 해제하고 다시 돌아오면 update가 되지 않은 것을 새로 구현했습니다.

---



## Screenshots 📸

https://user-images.githubusercontent.com/97531269/221407627-aec24f6b-59c2-4ef4-acf4-2dd415b58e09.mp4

## To Reviewers

https://byeon.is/swift-interactivepopgesturerecognizer-bug/
이 버그는 현재 유명한 서비스하고 있는 앱들도 많이 발생하는 버그랍니다..
자세한 것은 위 블로그 참고해주세요 ~! 